### PR TITLE
fix wrong plugin directory

### DIFF
--- a/src/condenser.js
+++ b/src/condenser.js
@@ -33,7 +33,7 @@ var defs = function (libs) {
 }
 
 var server = function (config, dir) {
-  var base = path.resolve(__dirname, '../node_modules/tern/defs')
+  var base = path.resolve(__dirname, '../node_modules/tern/plugin')
   
   Object.keys(config.plugins).forEach(function (plugin) {
     var file = path.join(base, interpolate('%s.js', plugin))


### PR DESCRIPTION
Plugins from .tern-project were never loaded before. With that fix, as an example the ```requirejs``` plugin get's loaded and Tern reports symbols from AMD modules. ```jsctags``` doesn't extract something meaningful out of Tern's data yet, though.