### PR TITLE
Allow multiple input files

### DIFF
--- a/bin/jsctags
+++ b/bin/jsctags
@@ -34,7 +34,15 @@ if(!argv._.length) {
   process.stdin.on('end', function () {
     jsctags(file, dir, content, function (e, tags) {
       if(e) throw e
-      console.log(JSON.stringify(tags, null, 2))
+      tags.tagfile = file
+      tags.forEach(function (tag) {
+        tag.tagfile = file
+      })
+	  if (argv.f) {
+        console.log(jsctags.ctags(tags).sort().join(''))
+      } else {
+        console.log(JSON.stringify(tags, null, 2))
+      }
     })
   })
 } else {

--- a/bin/jsctags
+++ b/bin/jsctags
@@ -54,11 +54,8 @@ if(!argv._.length) {
   }, function (e, results) {
     if(e) throw e
     if(argv.f) {
-      return results.forEach(function (tags) {
-        jsctags.ctags(tags).forEach(function (tag) {
-          process.stdout.write(tag)
-        })
-      })
+      var ctags = Array.prototype.concat.apply([], results.map(jsctags.ctags))
+      console.log(ctags.sort().join(''))
     } else {
       var tags = Array.prototype.concat.apply([], results)
       console.log(JSON.stringify(tags, null, 2))

--- a/bin/jsctags
+++ b/bin/jsctags
@@ -4,7 +4,8 @@ var interpolate = require('util').format,
     argv = require('optimist').argv,
     jsctags = require('../'),
     path = require('path'),
-    fs = require('fs')
+    fs = require('fs'),
+    async = require('async')
 
 var dir = (function () {
   if(argv.dir) return path.resolve(argv.dir)
@@ -15,19 +16,15 @@ var dir = (function () {
 
 var file = (function () {
   if(argv.file) return path.resolve(process.cwd(), argv.file)
-  if(argv._.length) return path.resolve(process.cwd(), argv._[0])
+  if(argv._.length) return argv._.map(function (file) {
+    return path.resolve(process.cwd(), file)
+  })
   return interpolate('///null/%s', Math.floor(Math.random()*100))
 })()
 
-var content = ''
-
-var to_ctags = function (tags) {
-  jsctags.ctags(tags).map(function (tag) {
-    console.log(tag)
-  })
-}
-
 if(!argv._.length) {
+  var content = ''
+
   process.stdin.resume()
 
   process.stdin.on('data', function (data) {
@@ -41,14 +38,30 @@ if(!argv._.length) {
     })
   })
 } else {
-  content = fs.readFileSync(file, 'utf8')
-  jsctags(file, dir, content, function (e, tags) {
+  var files = Array.isArray(file) ? file : [file]
+  async.map(files, function (file, callback) {
+    fs.readFile(file, 'utf8', function (e, content) {
+      if(e) return callback(e)
+      jsctags(file, dir, content, function (e, tags) {
+        if(e) return callback(e)
+        tags.tagfile = file
+        tags.forEach(function (tag) {
+          tag.tagfile = file
+        })
+        return callback(null, tags)
+      })
+    })
+  }, function (e, results) {
     if(e) throw e
     if(argv.f) {
-      tags.tagfile = file;
-      return to_ctags(tags)
+      return results.forEach(function (tags) {
+        jsctags.ctags(tags).forEach(function (tag) {
+          process.stdout.write(tag)
+        })
+      })
+    } else {
+      var tags = Array.prototype.concat.apply([], results)
+      console.log(JSON.stringify(tags, null, 2))
     }
-
-    console.log(JSON.stringify(tags, null, 2))
   })
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "node test/runner.js"
   },
   "dependencies": {
+    "async": "^1.4.2",
     "deepmerge": "0.2.x",
     "optimist": "0.6.x",
     "tern": "latest",

--- a/test/cases/_.json
+++ b/test/cases/_.json
@@ -1,0 +1,917 @@
+[
+  {
+    "name": "arguments",
+    "addr": "/arguments/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/arguments.js"
+  },
+  {
+    "name": "Bar",
+    "addr": "/Bar/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/autothis.js"
+  },
+  {
+    "name": "hallo",
+    "addr": "/hallo/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 2,
+    "namespace": "Bar.prototype",
+    "tagfile": "__DIR__/autothis.js"
+  },
+  {
+    "name": "fn2",
+    "addr": "/fn2/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 11,
+    "namespace": "Date.prototype",
+    "tagfile": "__DIR__/autothis.js"
+  },
+  {
+    "name": "newElt",
+    "addr": "/newElt/",
+    "kind": "v",
+    "type": "+Element",
+    "lineno": 5,
+    "tagfile": "__DIR__/browser.js"
+  },
+  {
+    "name": "e_which",
+    "addr": "/e_which/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 9,
+    "tagfile": "__DIR__/browser.js"
+  },
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/builtins.js"
+  },
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "[number]",
+    "lineno": 4,
+    "tagfile": "__DIR__/builtins.js"
+  },
+  {
+    "name": "num",
+    "addr": "/num/",
+    "kind": "v",
+    "type": "+Number",
+    "lineno": 26,
+    "tagfile": "__DIR__/builtins.js"
+  },
+  {
+    "name": "inner",
+    "addr": "/inner/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 5,
+    "tagfile": "__DIR__/cautiouspropagation.js"
+  },
+  {
+    "name": "<i>",
+    "addr": "/foo\\(\\)/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 9,
+    "namespace": "simple",
+    "tagfile": "__DIR__/cautiouspropagation.js"
+  },
+  {
+    "name": "buildCopy",
+    "addr": "/buildCopy/",
+    "kind": "f",
+    "type": "? function(buildCopy.!0)",
+    "lineno": 1,
+    "tagfile": "__DIR__/copyprops.js"
+  },
+  {
+    "name": "Ctor",
+    "addr": "/Ctor/",
+    "kind": "f",
+    "type": "+Ctor function()",
+    "lineno": 4,
+    "tagfile": "__DIR__/ctorpattern.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "Ctor",
+    "tagfile": "__DIR__/ctorpattern.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 9,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "makeMonkey",
+    "addr": "/makeMonkey/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 14,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "abc",
+    "addr": "/abc/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 26,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "Quux",
+    "addr": "/Quux/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 33,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "baz",
+    "addr": "/baz/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 40,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "getName",
+    "addr": "/getName/",
+    "kind": "f",
+    "type": "!this.name function()",
+    "lineno": 46,
+    "namespace": "o",
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "name",
+    "addr": "/name/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 48,
+    "namespace": "o",
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 52,
+    "namespace": "o",
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "b",
+    "addr": "/b/",
+    "kind": "v",
+    "type": "[bool]",
+    "lineno": 3,
+    "tagfile": "__DIR__/effects.js"
+  },
+  {
+    "name": "c",
+    "addr": "/c/",
+    "kind": "v",
+    "type": "[string|number]",
+    "lineno": 7,
+    "tagfile": "__DIR__/effects.js"
+  },
+  {
+    "name": "d",
+    "addr": "/d/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 12,
+    "tagfile": "__DIR__/effects.js"
+  },
+  {
+    "name": "setD",
+    "addr": "/setD/",
+    "kind": "f",
+    "type": "void function(number)",
+    "lineno": 13,
+    "tagfile": "__DIR__/effects.js"
+  },
+  {
+    "name": "__extends",
+    "addr": "/__extends/",
+    "kind": "f",
+    "type": "void function(fn(arg: bool)",
+    "lineno": 3,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "Top",
+    "addr": "/Top/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 10,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "topMethod",
+    "addr": "/topMethod/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 12,
+    "namespace": "Top.prototype",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "topStatic",
+    "addr": "/topStatic/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 13,
+    "namespace": "Top",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "SubOne",
+    "addr": "/SubOne/",
+    "kind": "f",
+    "type": "void function(bool)",
+    "lineno": 17,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "argOne",
+    "addr": "/argOne/",
+    "kind": "v",
+    "type": "boolean",
+    "lineno": 18,
+    "namespace": "SubOne",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "argOne",
+    "addr": "/argOne/",
+    "kind": "v",
+    "type": "boolean",
+    "lineno": 18,
+    "namespace": "SubEleven",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "methodOne",
+    "addr": "/methodOne/",
+    "kind": "f",
+    "type": "number function()",
+    "lineno": 20,
+    "namespace": "SubOne.prototype",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "SubTwo",
+    "addr": "/SubTwo/",
+    "kind": "f",
+    "type": "void function(bool)",
+    "lineno": 24,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "argTwo",
+    "addr": "/argTwo/",
+    "kind": "v",
+    "type": "boolean",
+    "lineno": 25,
+    "namespace": "SubTwo",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "methodTwo",
+    "addr": "/methodTwo/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 27,
+    "namespace": "SubTwo.prototype",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "SubEleven",
+    "addr": "/SubEleven/",
+    "kind": "f",
+    "type": "void function(bool)",
+    "lineno": 31,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "methodEleven",
+    "addr": "/methodEleven/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 34,
+    "namespace": "SubEleven.prototype",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "one",
+    "addr": "/one/",
+    "kind": "v",
+    "type": "+SubOne",
+    "lineno": 38,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "two",
+    "addr": "/two/",
+    "kind": "v",
+    "type": "+SubTwo",
+    "lineno": 38,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "elf",
+    "addr": "/elf/",
+    "kind": "v",
+    "type": "+SubEleven",
+    "lineno": 38,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "blah",
+    "addr": "/blah/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "jaja",
+    "addr": "/jaja/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 3,
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "prop1",
+    "addr": "/prop1/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "obj",
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "prop2",
+    "addr": "/prop2/",
+    "kind": "f",
+    "type": "void function(?)",
+    "lineno": 7,
+    "namespace": "obj",
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "prop3",
+    "addr": "/prop3/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 10,
+    "namespace": "obj",
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "hide",
+    "addr": "/hide/",
+    "kind": "f",
+    "type": "fn(foo: ?) function()",
+    "lineno": 19,
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "another",
+    "addr": "/another/",
+    "kind": "f",
+    "type": "void function(?)",
+    "lineno": 23,
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "hello",
+    "addr": "/hello/",
+    "kind": "f",
+    "type": "void function(?, ?)",
+    "lineno": 1,
+    "tagfile": "__DIR__/findref.js"
+  },
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 11,
+    "namespace": "obj",
+    "tagfile": "__DIR__/findref.js"
+  },
+  {
+    "name": "y",
+    "addr": "/y/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 13,
+    "namespace": "obj",
+    "tagfile": "__DIR__/findref.js"
+  },
+  {
+    "name": "z",
+    "addr": "/z/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 17,
+    "namespace": "obj",
+    "tagfile": "__DIR__/findref.js"
+  },
+  {
+    "name": "abc",
+    "addr": "/abc/",
+    "kind": "f",
+    "type": "number function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/fn_arguments.js"
+  },
+  {
+    "name": "each",
+    "addr": "/each/",
+    "kind": "f",
+    "type": "void function(Array[number]|[each.!0.<i>], fn(n: number)",
+    "lineno": 2,
+    "tagfile": "__DIR__/generic_each.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/global_this.js"
+  },
+  {
+    "name": "f",
+    "addr": "/f/",
+    "kind": "f",
+    "type": "void function(f)",
+    "lineno": 3,
+    "tagfile": "__DIR__/infinite-expansion.js"
+  },
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "[x]",
+    "lineno": 10,
+    "tagfile": "__DIR__/infinite-expansion.js"
+  },
+  {
+    "name": "goop",
+    "addr": "/goop/",
+    "kind": "f",
+    "type": "fn(f: ?) function(number)",
+    "lineno": 15,
+    "tagfile": "__DIR__/infinite-expansion.js"
+  },
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "+Date",
+    "lineno": 2,
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "f",
+    "type": "Array function(number, string)",
+    "lineno": 17,
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "bar",
+    "addr": "/bar/",
+    "kind": "f",
+    "type": "string function(number, number)",
+    "lineno": 25,
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "prop1",
+    "addr": "/prop1/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 31,
+    "namespace": "o",
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "prop2",
+    "addr": "/prop2/",
+    "kind": "f",
+    "type": "number function()",
+    "lineno": 34,
+    "namespace": "o",
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "prop3",
+    "addr": "/prop3/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 38,
+    "namespace": "o",
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "sum",
+    "addr": "/sum/",
+    "kind": "f",
+    "type": "number function(?)",
+    "lineno": 1,
+    "tagfile": "__DIR__/merge.js"
+  },
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "[string]",
+    "lineno": 1,
+    "tagfile": "__DIR__/new_array.js"
+  },
+  {
+    "name": "b",
+    "addr": "/b/",
+    "kind": "v",
+    "type": "[bool]",
+    "lineno": 5,
+    "tagfile": "__DIR__/new_array.js"
+  },
+  {
+    "name": "c",
+    "addr": "/c/",
+    "kind": "v",
+    "type": "[?]",
+    "lineno": 8,
+    "tagfile": "__DIR__/new_array.js"
+  },
+  {
+    "name": "d",
+    "addr": "/d/",
+    "kind": "v",
+    "type": "[string]",
+    "lineno": 11,
+    "tagfile": "__DIR__/new_array.js"
+  },
+  {
+    "name": "A",
+    "addr": "/A/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "prop_A",
+    "addr": "/prop_A/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 2,
+    "namespace": "A.prototype",
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "B",
+    "addr": "/B/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 3,
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "prop_B",
+    "addr": "/prop_B/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 5,
+    "namespace": "B.prototype",
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "C",
+    "addr": "/C/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 6,
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "prop_C",
+    "addr": "/prop_C/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 8,
+    "namespace": "C.prototype",
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "namespace": "base",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "bar",
+    "addr": "/bar/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "namespace": "base",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "baz",
+    "addr": "/baz/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 5,
+    "namespace": "base",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "quux",
+    "addr": "/quux/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "gen1",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "kaka",
+    "addr": "/kaka/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 7,
+    "namespace": "gen2",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "prop1",
+    "addr": "/prop1/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 30,
+    "namespace": "empty",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "Ctor1",
+    "addr": "/Ctor1/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/objnames.js"
+  },
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 2,
+    "namespace": "Ctor1.prototype",
+    "tagfile": "__DIR__/objnames.js"
+  },
+  {
+    "name": "Ctor2",
+    "addr": "/Ctor2/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 4,
+    "tagfile": "__DIR__/objnames.js"
+  },
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "singleton",
+    "tagfile": "__DIR__/objnames.js"
+  },
+  {
+    "name": "b",
+    "addr": "/b/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "singleton",
+    "tagfile": "__DIR__/objnames.js"
+  },
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/plus.js"
+  },
+  {
+    "name": "y",
+    "addr": "/y/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 2,
+    "tagfile": "__DIR__/plus.js"
+  },
+  {
+    "name": "Foo",
+    "addr": "/Foo/",
+    "kind": "f",
+    "type": "void function(bool)",
+    "lineno": 1,
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "boolean",
+    "lineno": 2,
+    "namespace": "Foo",
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "y",
+    "addr": "/y/",
+    "kind": "v",
+    "type": "[number]",
+    "lineno": 3,
+    "namespace": "Foo",
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "makeString",
+    "addr": "/makeString/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 8,
+    "namespace": "Foo.prototype",
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "bar",
+    "addr": "/bar/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 9,
+    "namespace": "Foo.prototype",
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "z",
+    "addr": "/z/",
+    "kind": "v",
+    "type": "+Foo",
+    "lineno": 12,
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "Base",
+    "addr": "/Base/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/protoname.js"
+  },
+  {
+    "name": "Sub1",
+    "addr": "/Sub1/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 7,
+    "tagfile": "__DIR__/protoname.js"
+  },
+  {
+    "name": "Sub2",
+    "addr": "/Sub2/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 11,
+    "tagfile": "__DIR__/protoname.js"
+  },
+  {
+    "name": "Base2",
+    "addr": "/Base2/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 15,
+    "tagfile": "__DIR__/protoname.js"
+  },
+  {
+    "name": "Sub3",
+    "addr": "/Sub3/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 17,
+    "tagfile": "__DIR__/protoname.js"
+  },
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "+Type",
+    "lineno": 1,
+    "tagfile": "__DIR__/replace_bogus_prop.js"
+  },
+  {
+    "name": "Type",
+    "addr": "/Type/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 5,
+    "tagfile": "__DIR__/replace_bogus_prop.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 6,
+    "namespace": "Type.prototype",
+    "tagfile": "__DIR__/replace_bogus_prop.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/simple.js"
+  },
+  {
+    "name": "init",
+    "addr": "/init/",
+    "kind": "f",
+    "type": "void function(x)",
+    "lineno": 8,
+    "tagfile": "__DIR__/simple.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 9,
+    "namespace": "x",
+    "tagfile": "__DIR__/simple.js"
+  },
+  {
+    "name": "bar",
+    "addr": "/bar/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 10,
+    "namespace": "x",
+    "tagfile": "__DIR__/simple.js"
+  },
+  {
+    "name": "last",
+    "addr": "/last/",
+    "kind": "f",
+    "type": "!0.<i> function(Array[number]|[string])",
+    "lineno": 1,
+    "tagfile": "__DIR__/simple_generic.js"
+  },
+  {
+    "name": "map",
+    "addr": "/map/",
+    "kind": "f",
+    "type": "string|fn() -> bool) -> [?] function(Array[number], fn()",
+    "lineno": 6,
+    "tagfile": "__DIR__/simple_generic.js"
+  }
+]

--- a/test/cases/_.tags
+++ b/test/cases/_.tags
@@ -1,0 +1,110 @@
+<i>	__DIR__/cautiouspropagation.js	/foo\(\)/;"	v	lineno:9	namespace:simple	type:string
+A	__DIR__/new_to_prototype.js	/A/;"	f	lineno:1	type:void function()
+B	__DIR__/new_to_prototype.js	/B/;"	f	lineno:3	type:void function()
+Bar	__DIR__/autothis.js	/Bar/;"	f	lineno:1	type:void function()
+Base	__DIR__/protoname.js	/Base/;"	f	lineno:1	type:void function()
+Base2	__DIR__/protoname.js	/Base2/;"	f	lineno:15	type:void function()
+C	__DIR__/new_to_prototype.js	/C/;"	f	lineno:6	type:void function()
+Ctor	__DIR__/ctorpattern.js	/Ctor/;"	f	lineno:4	type:+Ctor function()
+Ctor1	__DIR__/objnames.js	/Ctor1/;"	f	lineno:1	type:void function()
+Ctor2	__DIR__/objnames.js	/Ctor2/;"	f	lineno:4	type:void function()
+Foo	__DIR__/proto.js	/Foo/;"	f	lineno:1	type:void function(bool)
+Quux	__DIR__/docstrings.js	/Quux/;"	f	lineno:33	type:void function()
+Sub1	__DIR__/protoname.js	/Sub1/;"	f	lineno:7	type:void function()
+Sub2	__DIR__/protoname.js	/Sub2/;"	f	lineno:11	type:void function()
+Sub3	__DIR__/protoname.js	/Sub3/;"	f	lineno:17	type:void function()
+SubEleven	__DIR__/extends.js	/SubEleven/;"	f	lineno:31	type:void function(bool)
+SubOne	__DIR__/extends.js	/SubOne/;"	f	lineno:17	type:void function(bool)
+SubTwo	__DIR__/extends.js	/SubTwo/;"	f	lineno:24	type:void function(bool)
+Top	__DIR__/extends.js	/Top/;"	f	lineno:10	type:void function()
+Type	__DIR__/replace_bogus_prop.js	/Type/;"	f	lineno:5	type:void function()
+__extends	__DIR__/extends.js	/__extends/;"	f	lineno:3	type:void function(fn(arg: bool)
+a	__DIR__/builtins.js	/a/;"	v	lineno:4	type:[number]
+a	__DIR__/jsdoc.js	/a/;"	v	lineno:2	type:+Date
+a	__DIR__/new_array.js	/a/;"	v	lineno:1	type:[string]
+a	__DIR__/objnames.js	/a/;"	v	lineno:2	namespace:Ctor1.prototype	type:number
+a	__DIR__/objnames.js	/a/;"	v	lineno:6	namespace:singleton	type:number
+abc	__DIR__/docstrings.js	/abc/;"	v	lineno:26	type:number
+abc	__DIR__/fn_arguments.js	/abc/;"	f	lineno:1	type:number function()
+another	__DIR__/finddef.js	/another/;"	f	lineno:23	type:void function(?)
+argOne	__DIR__/extends.js	/argOne/;"	v	lineno:18	namespace:SubEleven	type:boolean
+argOne	__DIR__/extends.js	/argOne/;"	v	lineno:18	namespace:SubOne	type:boolean
+argTwo	__DIR__/extends.js	/argTwo/;"	v	lineno:25	namespace:SubTwo	type:boolean
+arguments	__DIR__/arguments.js	/arguments/;"	v	lineno:1	type:number
+b	__DIR__/effects.js	/b/;"	v	lineno:3	type:[bool]
+b	__DIR__/new_array.js	/b/;"	v	lineno:5	type:[bool]
+b	__DIR__/objnames.js	/b/;"	v	lineno:6	namespace:singleton	type:number
+bar	__DIR__/jsdoc.js	/bar/;"	f	lineno:25	type:string function(number, number)
+bar	__DIR__/object_create.js	/bar/;"	v	lineno:1	namespace:base	type:number
+bar	__DIR__/proto.js	/bar/;"	v	lineno:9	namespace:Foo.prototype	type:number
+bar	__DIR__/simple.js	/bar/;"	v	lineno:10	namespace:x	type:number
+baz	__DIR__/docstrings.js	/baz/;"	v	lineno:40	type:string
+baz	__DIR__/object_create.js	/baz/;"	v	lineno:5	namespace:base	type:number
+blah	__DIR__/finddef.js	/blah/;"	f	lineno:1	type:void function()
+buildCopy	__DIR__/copyprops.js	/buildCopy/;"	f	lineno:1	type:? function(buildCopy.!0)
+c	__DIR__/effects.js	/c/;"	v	lineno:7	type:[string|number]
+c	__DIR__/new_array.js	/c/;"	v	lineno:8	type:[?]
+d	__DIR__/effects.js	/d/;"	v	lineno:12	type:number
+d	__DIR__/new_array.js	/d/;"	v	lineno:11	type:[string]
+e_which	__DIR__/browser.js	/e_which/;"	v	lineno:9	type:number
+each	__DIR__/generic_each.js	/each/;"	f	lineno:2	type:void function(Array[number]|[each.!0.<i>], fn(n: number)
+elf	__DIR__/extends.js	/elf/;"	v	lineno:38	type:+SubEleven
+f	__DIR__/infinite-expansion.js	/f/;"	f	lineno:3	type:void function(f)
+fn2	__DIR__/autothis.js	/fn2/;"	f	lineno:11	namespace:Date.prototype	type:void function()
+foo	__DIR__/ctorpattern.js	/foo/;"	v	lineno:6	namespace:Ctor	type:number
+foo	__DIR__/docstrings.js	/foo/;"	v	lineno:52	namespace:o	type:string
+foo	__DIR__/docstrings.js	/foo/;"	v	lineno:9	type:number
+foo	__DIR__/global_this.js	/foo/;"	v	lineno:1	type:number
+foo	__DIR__/jsdoc.js	/foo/;"	f	lineno:17	type:Array function(number, string)
+foo	__DIR__/object_create.js	/foo/;"	v	lineno:1	namespace:base	type:number
+foo	__DIR__/replace_bogus_prop.js	/foo/;"	v	lineno:6	namespace:Type.prototype	type:string
+foo	__DIR__/simple.js	/foo/;"	v	lineno:1	type:number
+foo	__DIR__/simple.js	/foo/;"	v	lineno:9	namespace:x	type:number
+getName	__DIR__/docstrings.js	/getName/;"	f	lineno:46	namespace:o	type:!this.name function()
+goop	__DIR__/infinite-expansion.js	/goop/;"	f	lineno:15	type:fn(f: ?) function(number)
+hallo	__DIR__/autothis.js	/hallo/;"	f	lineno:2	namespace:Bar.prototype	type:void function()
+hello	__DIR__/findref.js	/hello/;"	f	lineno:1	type:void function(?, ?)
+hide	__DIR__/finddef.js	/hide/;"	f	lineno:19	type:fn(foo: ?) function()
+init	__DIR__/simple.js	/init/;"	f	lineno:8	type:void function(x)
+inner	__DIR__/cautiouspropagation.js	/inner/;"	v	lineno:5	type:number
+jaja	__DIR__/finddef.js	/jaja/;"	v	lineno:3	type:number
+kaka	__DIR__/object_create.js	/kaka/;"	v	lineno:7	namespace:gen2	type:number
+last	__DIR__/simple_generic.js	/last/;"	f	lineno:1	type:!0.<i> function(Array[number]|[string])
+makeMonkey	__DIR__/docstrings.js	/makeMonkey/;"	f	lineno:14	type:string function()
+makeString	__DIR__/proto.js	/makeString/;"	f	lineno:8	namespace:Foo.prototype	type:string function()
+map	__DIR__/simple_generic.js	/map/;"	f	lineno:6	type:string|fn() -> bool) -> [?] function(Array[number], fn()
+methodEleven	__DIR__/extends.js	/methodEleven/;"	f	lineno:34	namespace:SubEleven.prototype	type:string function()
+methodOne	__DIR__/extends.js	/methodOne/;"	f	lineno:20	namespace:SubOne.prototype	type:number function()
+methodTwo	__DIR__/extends.js	/methodTwo/;"	f	lineno:27	namespace:SubTwo.prototype	type:void function()
+name	__DIR__/docstrings.js	/name/;"	v	lineno:48	namespace:o	type:string
+newElt	__DIR__/browser.js	/newElt/;"	v	lineno:5	type:+Element
+num	__DIR__/builtins.js	/num/;"	v	lineno:26	type:+Number
+one	__DIR__/extends.js	/one/;"	v	lineno:38	type:+SubOne
+prop1	__DIR__/finddef.js	/prop1/;"	v	lineno:6	namespace:obj	type:number
+prop1	__DIR__/jsdoc.js	/prop1/;"	v	lineno:31	namespace:o	type:string
+prop1	__DIR__/object_create.js	/prop1/;"	v	lineno:30	namespace:empty	type:string
+prop2	__DIR__/finddef.js	/prop2/;"	f	lineno:7	namespace:obj	type:void function(?)
+prop2	__DIR__/jsdoc.js	/prop2/;"	f	lineno:34	namespace:o	type:number function()
+prop3	__DIR__/finddef.js	/prop3/;"	v	lineno:10	namespace:obj	type:string
+prop3	__DIR__/jsdoc.js	/prop3/;"	f	lineno:38	namespace:o	type:string function()
+prop_A	__DIR__/new_to_prototype.js	/prop_A/;"	v	lineno:2	namespace:A.prototype	type:number
+prop_B	__DIR__/new_to_prototype.js	/prop_B/;"	v	lineno:5	namespace:B.prototype	type:number
+prop_C	__DIR__/new_to_prototype.js	/prop_C/;"	v	lineno:8	namespace:C.prototype	type:number
+quux	__DIR__/object_create.js	/quux/;"	v	lineno:6	namespace:gen1	type:number
+setD	__DIR__/effects.js	/setD/;"	f	lineno:13	type:void function(number)
+sum	__DIR__/merge.js	/sum/;"	f	lineno:1	type:number function(?)
+topMethod	__DIR__/extends.js	/topMethod/;"	f	lineno:12	namespace:Top.prototype	type:string function()
+topStatic	__DIR__/extends.js	/topStatic/;"	v	lineno:13	namespace:Top	type:number
+two	__DIR__/extends.js	/two/;"	v	lineno:38	type:+SubTwo
+x	__DIR__/builtins.js	/x/;"	v	lineno:1	type:number
+x	__DIR__/findref.js	/x/;"	v	lineno:11	namespace:obj	type:number
+x	__DIR__/infinite-expansion.js	/x/;"	v	lineno:10	type:[x]
+x	__DIR__/plus.js	/x/;"	v	lineno:1	type:number
+x	__DIR__/proto.js	/x/;"	v	lineno:2	namespace:Foo	type:boolean
+x	__DIR__/replace_bogus_prop.js	/x/;"	v	lineno:1	type:+Type
+y	__DIR__/findref.js	/y/;"	v	lineno:13	namespace:obj	type:number
+y	__DIR__/plus.js	/y/;"	v	lineno:2	type:string
+y	__DIR__/proto.js	/y/;"	v	lineno:3	namespace:Foo	type:[number]
+z	__DIR__/findref.js	/z/;"	v	lineno:17	namespace:obj	type:string
+z	__DIR__/proto.js	/z/;"	v	lineno:12	type:+Foo
+

--- a/test/cases/arguments.json
+++ b/test/cases/arguments.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "arguments",
+    "addr": "/arguments/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/arguments.js"
+  }
+]

--- a/test/cases/arguments.tags
+++ b/test/cases/arguments.tags
@@ -1,0 +1,2 @@
+arguments	__DIR__/arguments.js	/arguments/;"	v	lineno:1	type:number
+

--- a/test/cases/autothis.json
+++ b/test/cases/autothis.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "Bar",
+    "addr": "/Bar/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/autothis.js"
+  },
+  {
+    "name": "hallo",
+    "addr": "/hallo/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 2,
+    "namespace": "Bar.prototype",
+    "tagfile": "__DIR__/autothis.js"
+  },
+  {
+    "name": "fn2",
+    "addr": "/fn2/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 11,
+    "namespace": "Date.prototype",
+    "tagfile": "__DIR__/autothis.js"
+  }
+]

--- a/test/cases/autothis.tags
+++ b/test/cases/autothis.tags
@@ -1,0 +1,4 @@
+Bar	__DIR__/autothis.js	/Bar/;"	f	lineno:1	type:void function()
+fn2	__DIR__/autothis.js	/fn2/;"	f	lineno:11	namespace:Date.prototype	type:void function()
+hallo	__DIR__/autothis.js	/hallo/;"	f	lineno:2	namespace:Bar.prototype	type:void function()
+

--- a/test/cases/browser.json
+++ b/test/cases/browser.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "newElt",
+    "addr": "/newElt/",
+    "kind": "v",
+    "type": "+Element",
+    "lineno": 5,
+    "tagfile": "__DIR__/browser.js"
+  },
+  {
+    "name": "e_which",
+    "addr": "/e_which/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 9,
+    "tagfile": "__DIR__/browser.js"
+  }
+]

--- a/test/cases/browser.tags
+++ b/test/cases/browser.tags
@@ -1,0 +1,3 @@
+e_which	__DIR__/browser.js	/e_which/;"	v	lineno:9	type:number
+newElt	__DIR__/browser.js	/newElt/;"	v	lineno:5	type:+Element
+

--- a/test/cases/builtins.json
+++ b/test/cases/builtins.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/builtins.js"
+  },
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "[number]",
+    "lineno": 4,
+    "tagfile": "__DIR__/builtins.js"
+  },
+  {
+    "name": "num",
+    "addr": "/num/",
+    "kind": "v",
+    "type": "+Number",
+    "lineno": 26,
+    "tagfile": "__DIR__/builtins.js"
+  }
+]

--- a/test/cases/builtins.tags
+++ b/test/cases/builtins.tags
@@ -1,0 +1,4 @@
+a	__DIR__/builtins.js	/a/;"	v	lineno:4	type:[number]
+num	__DIR__/builtins.js	/num/;"	v	lineno:26	type:+Number
+x	__DIR__/builtins.js	/x/;"	v	lineno:1	type:number
+

--- a/test/cases/cautiouspropagation.json
+++ b/test/cases/cautiouspropagation.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "inner",
+    "addr": "/inner/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 5,
+    "tagfile": "__DIR__/cautiouspropagation.js"
+  },
+  {
+    "name": "<i>",
+    "addr": "/foo\\(\\)/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 9,
+    "namespace": "simple",
+    "tagfile": "__DIR__/cautiouspropagation.js"
+  }
+]

--- a/test/cases/cautiouspropagation.tags
+++ b/test/cases/cautiouspropagation.tags
@@ -1,0 +1,3 @@
+<i>	__DIR__/cautiouspropagation.js	/foo\(\)/;"	v	lineno:9	namespace:simple	type:string
+inner	__DIR__/cautiouspropagation.js	/inner/;"	v	lineno:5	type:number
+

--- a/test/cases/copyprops.json
+++ b/test/cases/copyprops.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "buildCopy",
+    "addr": "/buildCopy/",
+    "kind": "f",
+    "type": "? function(buildCopy.!0)",
+    "lineno": 1,
+    "tagfile": "__DIR__/copyprops.js"
+  }
+]

--- a/test/cases/copyprops.tags
+++ b/test/cases/copyprops.tags
@@ -1,0 +1,2 @@
+buildCopy	__DIR__/copyprops.js	/buildCopy/;"	f	lineno:1	type:? function(buildCopy.!0)
+

--- a/test/cases/ctorpattern.json
+++ b/test/cases/ctorpattern.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "Ctor",
+    "addr": "/Ctor/",
+    "kind": "f",
+    "type": "+Ctor function()",
+    "lineno": 4,
+    "tagfile": "__DIR__/ctorpattern.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "Ctor",
+    "tagfile": "__DIR__/ctorpattern.js"
+  }
+]

--- a/test/cases/ctorpattern.tags
+++ b/test/cases/ctorpattern.tags
@@ -1,0 +1,3 @@
+Ctor	__DIR__/ctorpattern.js	/Ctor/;"	f	lineno:4	type:+Ctor function()
+foo	__DIR__/ctorpattern.js	/foo/;"	v	lineno:6	namespace:Ctor	type:number
+

--- a/test/cases/docstrings.json
+++ b/test/cases/docstrings.json
@@ -1,0 +1,69 @@
+[
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 9,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "makeMonkey",
+    "addr": "/makeMonkey/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 14,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "abc",
+    "addr": "/abc/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 26,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "Quux",
+    "addr": "/Quux/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 33,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "baz",
+    "addr": "/baz/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 40,
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "getName",
+    "addr": "/getName/",
+    "kind": "f",
+    "type": "!this.name function()",
+    "lineno": 46,
+    "namespace": "o",
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "name",
+    "addr": "/name/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 48,
+    "namespace": "o",
+    "tagfile": "__DIR__/docstrings.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 52,
+    "namespace": "o",
+    "tagfile": "__DIR__/docstrings.js"
+  }
+]

--- a/test/cases/docstrings.tags
+++ b/test/cases/docstrings.tags
@@ -1,0 +1,9 @@
+Quux	__DIR__/docstrings.js	/Quux/;"	f	lineno:33	type:void function()
+abc	__DIR__/docstrings.js	/abc/;"	v	lineno:26	type:number
+baz	__DIR__/docstrings.js	/baz/;"	v	lineno:40	type:string
+foo	__DIR__/docstrings.js	/foo/;"	v	lineno:52	namespace:o	type:string
+foo	__DIR__/docstrings.js	/foo/;"	v	lineno:9	type:number
+getName	__DIR__/docstrings.js	/getName/;"	f	lineno:46	namespace:o	type:!this.name function()
+makeMonkey	__DIR__/docstrings.js	/makeMonkey/;"	f	lineno:14	type:string function()
+name	__DIR__/docstrings.js	/name/;"	v	lineno:48	namespace:o	type:string
+

--- a/test/cases/effects.json
+++ b/test/cases/effects.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "b",
+    "addr": "/b/",
+    "kind": "v",
+    "type": "[bool]",
+    "lineno": 3,
+    "tagfile": "__DIR__/effects.js"
+  },
+  {
+    "name": "c",
+    "addr": "/c/",
+    "kind": "v",
+    "type": "[string|number]",
+    "lineno": 7,
+    "tagfile": "__DIR__/effects.js"
+  },
+  {
+    "name": "d",
+    "addr": "/d/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 12,
+    "tagfile": "__DIR__/effects.js"
+  },
+  {
+    "name": "setD",
+    "addr": "/setD/",
+    "kind": "f",
+    "type": "void function(number)",
+    "lineno": 13,
+    "tagfile": "__DIR__/effects.js"
+  }
+]

--- a/test/cases/effects.tags
+++ b/test/cases/effects.tags
@@ -1,0 +1,5 @@
+b	__DIR__/effects.js	/b/;"	v	lineno:3	type:[bool]
+c	__DIR__/effects.js	/c/;"	v	lineno:7	type:[string|number]
+d	__DIR__/effects.js	/d/;"	v	lineno:12	type:number
+setD	__DIR__/effects.js	/setD/;"	f	lineno:13	type:void function(number)
+

--- a/test/cases/extends.json
+++ b/test/cases/extends.json
@@ -1,0 +1,138 @@
+[
+  {
+    "name": "__extends",
+    "addr": "/__extends/",
+    "kind": "f",
+    "type": "void function(fn(arg: bool)",
+    "lineno": 3,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "Top",
+    "addr": "/Top/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 10,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "topMethod",
+    "addr": "/topMethod/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 12,
+    "namespace": "Top.prototype",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "topStatic",
+    "addr": "/topStatic/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 13,
+    "namespace": "Top",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "SubOne",
+    "addr": "/SubOne/",
+    "kind": "f",
+    "type": "void function(bool)",
+    "lineno": 17,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "argOne",
+    "addr": "/argOne/",
+    "kind": "v",
+    "type": "boolean",
+    "lineno": 18,
+    "namespace": "SubOne",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "argOne",
+    "addr": "/argOne/",
+    "kind": "v",
+    "type": "boolean",
+    "lineno": 18,
+    "namespace": "SubEleven",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "methodOne",
+    "addr": "/methodOne/",
+    "kind": "f",
+    "type": "number function()",
+    "lineno": 20,
+    "namespace": "SubOne.prototype",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "SubTwo",
+    "addr": "/SubTwo/",
+    "kind": "f",
+    "type": "void function(bool)",
+    "lineno": 24,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "argTwo",
+    "addr": "/argTwo/",
+    "kind": "v",
+    "type": "boolean",
+    "lineno": 25,
+    "namespace": "SubTwo",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "methodTwo",
+    "addr": "/methodTwo/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 27,
+    "namespace": "SubTwo.prototype",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "SubEleven",
+    "addr": "/SubEleven/",
+    "kind": "f",
+    "type": "void function(bool)",
+    "lineno": 31,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "methodEleven",
+    "addr": "/methodEleven/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 34,
+    "namespace": "SubEleven.prototype",
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "one",
+    "addr": "/one/",
+    "kind": "v",
+    "type": "+SubOne",
+    "lineno": 38,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "two",
+    "addr": "/two/",
+    "kind": "v",
+    "type": "+SubTwo",
+    "lineno": 38,
+    "tagfile": "__DIR__/extends.js"
+  },
+  {
+    "name": "elf",
+    "addr": "/elf/",
+    "kind": "v",
+    "type": "+SubEleven",
+    "lineno": 38,
+    "tagfile": "__DIR__/extends.js"
+  }
+]

--- a/test/cases/extends.tags
+++ b/test/cases/extends.tags
@@ -1,0 +1,17 @@
+SubEleven	__DIR__/extends.js	/SubEleven/;"	f	lineno:31	type:void function(bool)
+SubOne	__DIR__/extends.js	/SubOne/;"	f	lineno:17	type:void function(bool)
+SubTwo	__DIR__/extends.js	/SubTwo/;"	f	lineno:24	type:void function(bool)
+Top	__DIR__/extends.js	/Top/;"	f	lineno:10	type:void function()
+__extends	__DIR__/extends.js	/__extends/;"	f	lineno:3	type:void function(fn(arg: bool)
+argOne	__DIR__/extends.js	/argOne/;"	v	lineno:18	namespace:SubEleven	type:boolean
+argOne	__DIR__/extends.js	/argOne/;"	v	lineno:18	namespace:SubOne	type:boolean
+argTwo	__DIR__/extends.js	/argTwo/;"	v	lineno:25	namespace:SubTwo	type:boolean
+elf	__DIR__/extends.js	/elf/;"	v	lineno:38	type:+SubEleven
+methodEleven	__DIR__/extends.js	/methodEleven/;"	f	lineno:34	namespace:SubEleven.prototype	type:string function()
+methodOne	__DIR__/extends.js	/methodOne/;"	f	lineno:20	namespace:SubOne.prototype	type:number function()
+methodTwo	__DIR__/extends.js	/methodTwo/;"	f	lineno:27	namespace:SubTwo.prototype	type:void function()
+one	__DIR__/extends.js	/one/;"	v	lineno:38	type:+SubOne
+topMethod	__DIR__/extends.js	/topMethod/;"	f	lineno:12	namespace:Top.prototype	type:string function()
+topStatic	__DIR__/extends.js	/topStatic/;"	v	lineno:13	namespace:Top	type:number
+two	__DIR__/extends.js	/two/;"	v	lineno:38	type:+SubTwo
+

--- a/test/cases/finddef.json
+++ b/test/cases/finddef.json
@@ -1,0 +1,61 @@
+[
+  {
+    "name": "blah",
+    "addr": "/blah/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "jaja",
+    "addr": "/jaja/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 3,
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "prop1",
+    "addr": "/prop1/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "obj",
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "prop2",
+    "addr": "/prop2/",
+    "kind": "f",
+    "type": "void function(?)",
+    "lineno": 7,
+    "namespace": "obj",
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "prop3",
+    "addr": "/prop3/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 10,
+    "namespace": "obj",
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "hide",
+    "addr": "/hide/",
+    "kind": "f",
+    "type": "fn(foo: ?) function()",
+    "lineno": 19,
+    "tagfile": "__DIR__/finddef.js"
+  },
+  {
+    "name": "another",
+    "addr": "/another/",
+    "kind": "f",
+    "type": "void function(?)",
+    "lineno": 23,
+    "tagfile": "__DIR__/finddef.js"
+  }
+]

--- a/test/cases/finddef.tags
+++ b/test/cases/finddef.tags
@@ -1,0 +1,8 @@
+another	__DIR__/finddef.js	/another/;"	f	lineno:23	type:void function(?)
+blah	__DIR__/finddef.js	/blah/;"	f	lineno:1	type:void function()
+hide	__DIR__/finddef.js	/hide/;"	f	lineno:19	type:fn(foo: ?) function()
+jaja	__DIR__/finddef.js	/jaja/;"	v	lineno:3	type:number
+prop1	__DIR__/finddef.js	/prop1/;"	v	lineno:6	namespace:obj	type:number
+prop2	__DIR__/finddef.js	/prop2/;"	f	lineno:7	namespace:obj	type:void function(?)
+prop3	__DIR__/finddef.js	/prop3/;"	v	lineno:10	namespace:obj	type:string
+

--- a/test/cases/findref.json
+++ b/test/cases/findref.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "hello",
+    "addr": "/hello/",
+    "kind": "f",
+    "type": "void function(?, ?)",
+    "lineno": 1,
+    "tagfile": "__DIR__/findref.js"
+  },
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 11,
+    "namespace": "obj",
+    "tagfile": "__DIR__/findref.js"
+  },
+  {
+    "name": "y",
+    "addr": "/y/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 13,
+    "namespace": "obj",
+    "tagfile": "__DIR__/findref.js"
+  },
+  {
+    "name": "z",
+    "addr": "/z/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 17,
+    "namespace": "obj",
+    "tagfile": "__DIR__/findref.js"
+  }
+]

--- a/test/cases/findref.tags
+++ b/test/cases/findref.tags
@@ -1,0 +1,5 @@
+hello	__DIR__/findref.js	/hello/;"	f	lineno:1	type:void function(?, ?)
+x	__DIR__/findref.js	/x/;"	v	lineno:11	namespace:obj	type:number
+y	__DIR__/findref.js	/y/;"	v	lineno:13	namespace:obj	type:number
+z	__DIR__/findref.js	/z/;"	v	lineno:17	namespace:obj	type:string
+

--- a/test/cases/fn_arguments.json
+++ b/test/cases/fn_arguments.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "abc",
+    "addr": "/abc/",
+    "kind": "f",
+    "type": "number function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/fn_arguments.js"
+  }
+]

--- a/test/cases/fn_arguments.tags
+++ b/test/cases/fn_arguments.tags
@@ -1,0 +1,2 @@
+abc	__DIR__/fn_arguments.js	/abc/;"	f	lineno:1	type:number function()
+

--- a/test/cases/generic_each.json
+++ b/test/cases/generic_each.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "each",
+    "addr": "/each/",
+    "kind": "f",
+    "type": "void function(Array[number]|[each.!0.<i>], fn(n: number)",
+    "lineno": 2,
+    "tagfile": "__DIR__/generic_each.js"
+  }
+]

--- a/test/cases/generic_each.tags
+++ b/test/cases/generic_each.tags
@@ -1,0 +1,2 @@
+each	__DIR__/generic_each.js	/each/;"	f	lineno:2	type:void function(Array[number]|[each.!0.<i>], fn(n: number)
+

--- a/test/cases/global_this.json
+++ b/test/cases/global_this.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/global_this.js"
+  }
+]

--- a/test/cases/global_this.tags
+++ b/test/cases/global_this.tags
@@ -1,0 +1,2 @@
+foo	__DIR__/global_this.js	/foo/;"	v	lineno:1	type:number
+

--- a/test/cases/infinite-expansion.json
+++ b/test/cases/infinite-expansion.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "f",
+    "addr": "/f/",
+    "kind": "f",
+    "type": "void function(f)",
+    "lineno": 3,
+    "tagfile": "__DIR__/infinite-expansion.js"
+  },
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "[x]",
+    "lineno": 10,
+    "tagfile": "__DIR__/infinite-expansion.js"
+  },
+  {
+    "name": "goop",
+    "addr": "/goop/",
+    "kind": "f",
+    "type": "fn(f: ?) function(number)",
+    "lineno": 15,
+    "tagfile": "__DIR__/infinite-expansion.js"
+  }
+]

--- a/test/cases/infinite-expansion.tags
+++ b/test/cases/infinite-expansion.tags
@@ -1,0 +1,4 @@
+f	__DIR__/infinite-expansion.js	/f/;"	f	lineno:3	type:void function(f)
+goop	__DIR__/infinite-expansion.js	/goop/;"	f	lineno:15	type:fn(f: ?) function(number)
+x	__DIR__/infinite-expansion.js	/x/;"	v	lineno:10	type:[x]
+

--- a/test/cases/jsdoc.json
+++ b/test/cases/jsdoc.json
@@ -1,0 +1,53 @@
+[
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "+Date",
+    "lineno": 2,
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "f",
+    "type": "Array function(number, string)",
+    "lineno": 17,
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "bar",
+    "addr": "/bar/",
+    "kind": "f",
+    "type": "string function(number, number)",
+    "lineno": 25,
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "prop1",
+    "addr": "/prop1/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 31,
+    "namespace": "o",
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "prop2",
+    "addr": "/prop2/",
+    "kind": "f",
+    "type": "number function()",
+    "lineno": 34,
+    "namespace": "o",
+    "tagfile": "__DIR__/jsdoc.js"
+  },
+  {
+    "name": "prop3",
+    "addr": "/prop3/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 38,
+    "namespace": "o",
+    "tagfile": "__DIR__/jsdoc.js"
+  }
+]

--- a/test/cases/jsdoc.tags
+++ b/test/cases/jsdoc.tags
@@ -1,0 +1,7 @@
+a	__DIR__/jsdoc.js	/a/;"	v	lineno:2	type:+Date
+bar	__DIR__/jsdoc.js	/bar/;"	f	lineno:25	type:string function(number, number)
+foo	__DIR__/jsdoc.js	/foo/;"	f	lineno:17	type:Array function(number, string)
+prop1	__DIR__/jsdoc.js	/prop1/;"	v	lineno:31	namespace:o	type:string
+prop2	__DIR__/jsdoc.js	/prop2/;"	f	lineno:34	namespace:o	type:number function()
+prop3	__DIR__/jsdoc.js	/prop3/;"	f	lineno:38	namespace:o	type:string function()
+

--- a/test/cases/merge.json
+++ b/test/cases/merge.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "sum",
+    "addr": "/sum/",
+    "kind": "f",
+    "type": "number function(?)",
+    "lineno": 1,
+    "tagfile": "__DIR__/merge.js"
+  }
+]

--- a/test/cases/merge.tags
+++ b/test/cases/merge.tags
@@ -1,0 +1,2 @@
+sum	__DIR__/merge.js	/sum/;"	f	lineno:1	type:number function(?)
+

--- a/test/cases/new_array.json
+++ b/test/cases/new_array.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "[string]",
+    "lineno": 1,
+    "tagfile": "__DIR__/new_array.js"
+  },
+  {
+    "name": "b",
+    "addr": "/b/",
+    "kind": "v",
+    "type": "[bool]",
+    "lineno": 5,
+    "tagfile": "__DIR__/new_array.js"
+  },
+  {
+    "name": "c",
+    "addr": "/c/",
+    "kind": "v",
+    "type": "[?]",
+    "lineno": 8,
+    "tagfile": "__DIR__/new_array.js"
+  },
+  {
+    "name": "d",
+    "addr": "/d/",
+    "kind": "v",
+    "type": "[string]",
+    "lineno": 11,
+    "tagfile": "__DIR__/new_array.js"
+  }
+]

--- a/test/cases/new_array.tags
+++ b/test/cases/new_array.tags
@@ -1,0 +1,5 @@
+a	__DIR__/new_array.js	/a/;"	v	lineno:1	type:[string]
+b	__DIR__/new_array.js	/b/;"	v	lineno:5	type:[bool]
+c	__DIR__/new_array.js	/c/;"	v	lineno:8	type:[?]
+d	__DIR__/new_array.js	/d/;"	v	lineno:11	type:[string]
+

--- a/test/cases/new_to_prototype.json
+++ b/test/cases/new_to_prototype.json
@@ -1,0 +1,53 @@
+[
+  {
+    "name": "A",
+    "addr": "/A/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "prop_A",
+    "addr": "/prop_A/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 2,
+    "namespace": "A.prototype",
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "B",
+    "addr": "/B/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 3,
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "prop_B",
+    "addr": "/prop_B/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 5,
+    "namespace": "B.prototype",
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "C",
+    "addr": "/C/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 6,
+    "tagfile": "__DIR__/new_to_prototype.js"
+  },
+  {
+    "name": "prop_C",
+    "addr": "/prop_C/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 8,
+    "namespace": "C.prototype",
+    "tagfile": "__DIR__/new_to_prototype.js"
+  }
+]

--- a/test/cases/new_to_prototype.tags
+++ b/test/cases/new_to_prototype.tags
@@ -1,0 +1,7 @@
+A	__DIR__/new_to_prototype.js	/A/;"	f	lineno:1	type:void function()
+B	__DIR__/new_to_prototype.js	/B/;"	f	lineno:3	type:void function()
+C	__DIR__/new_to_prototype.js	/C/;"	f	lineno:6	type:void function()
+prop_A	__DIR__/new_to_prototype.js	/prop_A/;"	v	lineno:2	namespace:A.prototype	type:number
+prop_B	__DIR__/new_to_prototype.js	/prop_B/;"	v	lineno:5	namespace:B.prototype	type:number
+prop_C	__DIR__/new_to_prototype.js	/prop_C/;"	v	lineno:8	namespace:C.prototype	type:number
+

--- a/test/cases/object_create.json
+++ b/test/cases/object_create.json
@@ -1,0 +1,56 @@
+[
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "namespace": "base",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "bar",
+    "addr": "/bar/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "namespace": "base",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "baz",
+    "addr": "/baz/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 5,
+    "namespace": "base",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "quux",
+    "addr": "/quux/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "gen1",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "kaka",
+    "addr": "/kaka/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 7,
+    "namespace": "gen2",
+    "tagfile": "__DIR__/object_create.js"
+  },
+  {
+    "name": "prop1",
+    "addr": "/prop1/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 30,
+    "namespace": "empty",
+    "tagfile": "__DIR__/object_create.js"
+  }
+]

--- a/test/cases/object_create.tags
+++ b/test/cases/object_create.tags
@@ -1,0 +1,7 @@
+bar	__DIR__/object_create.js	/bar/;"	v	lineno:1	namespace:base	type:number
+baz	__DIR__/object_create.js	/baz/;"	v	lineno:5	namespace:base	type:number
+foo	__DIR__/object_create.js	/foo/;"	v	lineno:1	namespace:base	type:number
+kaka	__DIR__/object_create.js	/kaka/;"	v	lineno:7	namespace:gen2	type:number
+prop1	__DIR__/object_create.js	/prop1/;"	v	lineno:30	namespace:empty	type:string
+quux	__DIR__/object_create.js	/quux/;"	v	lineno:6	namespace:gen1	type:number
+

--- a/test/cases/objnames.json
+++ b/test/cases/objnames.json
@@ -1,0 +1,45 @@
+[
+  {
+    "name": "Ctor1",
+    "addr": "/Ctor1/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/objnames.js"
+  },
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 2,
+    "namespace": "Ctor1.prototype",
+    "tagfile": "__DIR__/objnames.js"
+  },
+  {
+    "name": "Ctor2",
+    "addr": "/Ctor2/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 4,
+    "tagfile": "__DIR__/objnames.js"
+  },
+  {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "singleton",
+    "tagfile": "__DIR__/objnames.js"
+  },
+  {
+    "name": "b",
+    "addr": "/b/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 6,
+    "namespace": "singleton",
+    "tagfile": "__DIR__/objnames.js"
+  }
+]

--- a/test/cases/objnames.tags
+++ b/test/cases/objnames.tags
@@ -1,0 +1,6 @@
+Ctor1	__DIR__/objnames.js	/Ctor1/;"	f	lineno:1	type:void function()
+Ctor2	__DIR__/objnames.js	/Ctor2/;"	f	lineno:4	type:void function()
+a	__DIR__/objnames.js	/a/;"	v	lineno:2	namespace:Ctor1.prototype	type:number
+a	__DIR__/objnames.js	/a/;"	v	lineno:6	namespace:singleton	type:number
+b	__DIR__/objnames.js	/b/;"	v	lineno:6	namespace:singleton	type:number
+

--- a/test/cases/plus.json
+++ b/test/cases/plus.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/plus.js"
+  },
+  {
+    "name": "y",
+    "addr": "/y/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 2,
+    "tagfile": "__DIR__/plus.js"
+  }
+]

--- a/test/cases/plus.tags
+++ b/test/cases/plus.tags
@@ -1,0 +1,3 @@
+x	__DIR__/plus.js	/x/;"	v	lineno:1	type:number
+y	__DIR__/plus.js	/y/;"	v	lineno:2	type:string
+

--- a/test/cases/proto.json
+++ b/test/cases/proto.json
@@ -1,0 +1,54 @@
+[
+  {
+    "name": "Foo",
+    "addr": "/Foo/",
+    "kind": "f",
+    "type": "void function(bool)",
+    "lineno": 1,
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "boolean",
+    "lineno": 2,
+    "namespace": "Foo",
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "y",
+    "addr": "/y/",
+    "kind": "v",
+    "type": "[number]",
+    "lineno": 3,
+    "namespace": "Foo",
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "makeString",
+    "addr": "/makeString/",
+    "kind": "f",
+    "type": "string function()",
+    "lineno": 8,
+    "namespace": "Foo.prototype",
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "bar",
+    "addr": "/bar/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 9,
+    "namespace": "Foo.prototype",
+    "tagfile": "__DIR__/proto.js"
+  },
+  {
+    "name": "z",
+    "addr": "/z/",
+    "kind": "v",
+    "type": "+Foo",
+    "lineno": 12,
+    "tagfile": "__DIR__/proto.js"
+  }
+]

--- a/test/cases/proto.tags
+++ b/test/cases/proto.tags
@@ -1,0 +1,7 @@
+Foo	__DIR__/proto.js	/Foo/;"	f	lineno:1	type:void function(bool)
+bar	__DIR__/proto.js	/bar/;"	v	lineno:9	namespace:Foo.prototype	type:number
+makeString	__DIR__/proto.js	/makeString/;"	f	lineno:8	namespace:Foo.prototype	type:string function()
+x	__DIR__/proto.js	/x/;"	v	lineno:2	namespace:Foo	type:boolean
+y	__DIR__/proto.js	/y/;"	v	lineno:3	namespace:Foo	type:[number]
+z	__DIR__/proto.js	/z/;"	v	lineno:12	type:+Foo
+

--- a/test/cases/protoname.json
+++ b/test/cases/protoname.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "Base",
+    "addr": "/Base/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 1,
+    "tagfile": "__DIR__/protoname.js"
+  },
+  {
+    "name": "Sub1",
+    "addr": "/Sub1/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 7,
+    "tagfile": "__DIR__/protoname.js"
+  },
+  {
+    "name": "Sub2",
+    "addr": "/Sub2/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 11,
+    "tagfile": "__DIR__/protoname.js"
+  },
+  {
+    "name": "Base2",
+    "addr": "/Base2/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 15,
+    "tagfile": "__DIR__/protoname.js"
+  },
+  {
+    "name": "Sub3",
+    "addr": "/Sub3/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 17,
+    "tagfile": "__DIR__/protoname.js"
+  }
+]

--- a/test/cases/protoname.tags
+++ b/test/cases/protoname.tags
@@ -1,0 +1,6 @@
+Base	__DIR__/protoname.js	/Base/;"	f	lineno:1	type:void function()
+Base2	__DIR__/protoname.js	/Base2/;"	f	lineno:15	type:void function()
+Sub1	__DIR__/protoname.js	/Sub1/;"	f	lineno:7	type:void function()
+Sub2	__DIR__/protoname.js	/Sub2/;"	f	lineno:11	type:void function()
+Sub3	__DIR__/protoname.js	/Sub3/;"	f	lineno:17	type:void function()
+

--- a/test/cases/replace_bogus_prop.json
+++ b/test/cases/replace_bogus_prop.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "x",
+    "addr": "/x/",
+    "kind": "v",
+    "type": "+Type",
+    "lineno": 1,
+    "tagfile": "__DIR__/replace_bogus_prop.js"
+  },
+  {
+    "name": "Type",
+    "addr": "/Type/",
+    "kind": "f",
+    "type": "void function()",
+    "lineno": 5,
+    "tagfile": "__DIR__/replace_bogus_prop.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 6,
+    "namespace": "Type.prototype",
+    "tagfile": "__DIR__/replace_bogus_prop.js"
+  }
+]

--- a/test/cases/replace_bogus_prop.tags
+++ b/test/cases/replace_bogus_prop.tags
@@ -1,0 +1,4 @@
+Type	__DIR__/replace_bogus_prop.js	/Type/;"	f	lineno:5	type:void function()
+foo	__DIR__/replace_bogus_prop.js	/foo/;"	v	lineno:6	namespace:Type.prototype	type:string
+x	__DIR__/replace_bogus_prop.js	/x/;"	v	lineno:1	type:+Type
+

--- a/test/cases/simple.json
+++ b/test/cases/simple.json
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 1,
+    "tagfile": "__DIR__/simple.js"
+  },
+  {
+    "name": "init",
+    "addr": "/init/",
+    "kind": "f",
+    "type": "void function(x)",
+    "lineno": 8,
+    "tagfile": "__DIR__/simple.js"
+  },
+  {
+    "name": "foo",
+    "addr": "/foo/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 9,
+    "namespace": "x",
+    "tagfile": "__DIR__/simple.js"
+  },
+  {
+    "name": "bar",
+    "addr": "/bar/",
+    "kind": "v",
+    "type": "number",
+    "lineno": 10,
+    "namespace": "x",
+    "tagfile": "__DIR__/simple.js"
+  }
+]

--- a/test/cases/simple.tags
+++ b/test/cases/simple.tags
@@ -1,0 +1,5 @@
+bar	__DIR__/simple.js	/bar/;"	v	lineno:10	namespace:x	type:number
+foo	__DIR__/simple.js	/foo/;"	v	lineno:1	type:number
+foo	__DIR__/simple.js	/foo/;"	v	lineno:9	namespace:x	type:number
+init	__DIR__/simple.js	/init/;"	f	lineno:8	type:void function(x)
+

--- a/test/cases/simple_generic.json
+++ b/test/cases/simple_generic.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "last",
+    "addr": "/last/",
+    "kind": "f",
+    "type": "!0.<i> function(Array[number]|[string])",
+    "lineno": 1,
+    "tagfile": "__DIR__/simple_generic.js"
+  },
+  {
+    "name": "map",
+    "addr": "/map/",
+    "kind": "f",
+    "type": "string|fn() -> bool) -> [?] function(Array[number], fn()",
+    "lineno": 6,
+    "tagfile": "__DIR__/simple_generic.js"
+  }
+]

--- a/test/cases/simple_generic.tags
+++ b/test/cases/simple_generic.tags
@@ -1,0 +1,3 @@
+last	__DIR__/simple_generic.js	/last/;"	f	lineno:1	type:!0.<i> function(Array[number]|[string])
+map	__DIR__/simple_generic.js	/map/;"	f	lineno:6	type:string|fn() -> bool) -> [?] function(Array[number], fn()
+

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,18 +1,168 @@
 var interpolate = require('util').format,
     cp = require('child_process'),
-    path = require('path')
+    fs = require('fs'),
+    path = require('path'),
+    async = require('async'),
+    assert = require('assert')
 
-var file = path.resolve(__dirname, './cases/extends.js')
-var cmd = path.resolve(__dirname, '../bin/jsctags')
-var dir = path.resolve(__dirname, '..')
-
-//jsctags --dir=/something file
-//jsctags file
-//cat | jsctags --dir --file
-//cat | jsctags --dir
-//cat | jsctags
-//cat | jsctags --file
-var start = Date.now()
-cp.exec(interpolate('%s %s', cmd, file), function (e, stdout, stderr) {
-  console.log(stdout)
+var casesDir = path.resolve(__dirname, 'cases')
+var files = fs.readdirSync(casesDir).filter(function (file) {
+  return path.extname(file) === '.js';
+}).map(function (file) {
+  return path.resolve(__dirname, 'cases', file)
 })
+var cmd = path.resolve(__dirname, '../bin/jsctags')
+
+var start = Date.now()
+
+async.series([
+  function (callback) {
+    console.log('\nTesting individual cases:\n');
+    async.eachSeries(files, function (file, callback) {
+      var expectedJsonFile = replaceFileExtension(file, '.json')
+      var expectedCtagsFile = replaceFileExtension(file, '.tags')
+      var expectedJson = fs.readFileSync(expectedJsonFile, 'utf8')
+      var expectedCtags = fs.readFileSync(expectedCtagsFile, 'utf8')
+      runTestCase({
+        input: file,
+        dir: casesDir,
+        expected: {
+          json: expectedJson,
+          ctags: expectedCtags
+        }
+      }, callback)
+    }, callback)
+  },
+  function (callback) {
+    console.log('\nTesting file sets:\n');
+    var input = files.join(' ')
+    var expectedJsonFile = path.resolve(__dirname, 'cases/_.json')
+    var expectedCtagsFile = path.resolve(__dirname, 'cases/_.tags')
+    var expectedJson = fs.readFileSync(expectedJsonFile, 'utf8')
+    var expectedCtags = fs.readFileSync(expectedCtagsFile, 'utf8')
+    runTestCase({
+      input: input,
+      dir: casesDir,
+      expected: {
+        json: expectedJson,
+        ctags: expectedCtags
+      }
+    }, callback)
+  }
+], function (e) {
+  if(e) throw e
+  var elapsed = Date.now() - start
+  console.log(successText(interpolate('\nTests %s in %ss', e ? 'failed' : 'passed', elapsed / 1000)))
+})
+
+function replaceFileExtension(file, extension) {
+  return path.resolve(path.dirname(file), path.basename(file, path.extname(file)) + extension)
+}
+
+function runTestCase(options, callback) {
+  var file = options.input
+  var filename = file.split(' ').map(path.basename).join(' ')
+  var dir = options.dir
+  var expectedJson = options.expected.json.replace(/__DIR__/g, dir)
+  var expectedCtags = options.expected.ctags.replace(/__DIR__/g, dir)
+  var tests = [
+    function (callback) {
+      testCommandOutput({
+        input: {
+          file: file,
+          stdin: null
+        },
+        filename: filename,
+        args: null,
+        expected: expectedJson
+      }, callback)
+    },
+    function (callback) {
+      testCommandOutput({
+        input: {
+          file: file,
+          stdin: null
+        },
+        filename: filename,
+        args: ['-f'],
+        expected: expectedCtags
+      }, callback)
+    }
+  ]
+  if(file.split(' ').length === 1) {
+    tests.push(
+      function (callback) {
+        var content = fs.readFileSync(file, 'utf8')
+        testCommandOutput({
+          input: {
+            file: null,
+            stdin: content
+          },
+          filename: filename,
+          args: ['--file', file],
+          expected: expectedJson
+        }, callback)
+      },  
+      function (callback) {
+        var content = fs.readFileSync(file, 'utf8')
+        testCommandOutput({
+          input: {
+            file: null,
+            stdin: content
+          },
+          filename: filename,
+          args: ['-f', '--file', file],
+          expected: expectedCtags
+        }, callback)
+      }
+    )
+  }
+  async.series(tests, callback)
+}
+
+function testCommandOutput(options, callback) {
+  var file = options.input.file
+  var stdin = options.input.stdin
+  var filename = options.filename
+  var args = options.args || []
+  var expected = options.expected
+  process.stdout.write(interpolate('%s%s%s...', filename, file ? '' : ' (STDIN)', args.indexOf('-f') !== -1 ? ' (-f)' : ''))
+  var command = file ? interpolate('%s %s %s', cmd, file, args.join(' ')) : interpolate('%s %s', cmd, args.join(' '))
+  var child = cp.exec(command, function (e, stdout, stderr) {
+    if(e) return callback(e)
+    try {
+      if(args.indexOf('-f') === -1) {
+        assert.deepEqual(JSON.parse(stdout), JSON.parse(expected))
+      } else {
+        assert.equal(stdout, expected)
+      }
+      showTestPassed()
+    } catch(e) {
+      showTestFailed(stdout, expected)
+      throw e
+    }
+    callback(null)
+  })
+  if(!file) {
+    child.stdin.write(stdin)
+    child.stdin.end()
+  }
+}
+
+function showTestPassed() {
+  console.log(successText('OK'))
+}
+
+function showTestFailed(actual, expected) {
+  console.log(errorText('FAIL'))
+  console.log('\nExpected:\n\n' + expected)
+  console.log('\nActual:\n\n' + actual)
+}
+
+function successText(string) {
+  return '\u001b[32m' + string + '\u001b[39m'
+}
+
+function errorText(string) {
+  return '\u001b[31m' + string + '\u001b[39m'
+}


### PR DESCRIPTION
This PR allows the `jsctags` executable to accept multiple input files, as follows:

```bash
jsctags index.js server.js
```

```bash
jsctags *.js -f
```

...it also removes the double line breaks in the `-f` ctags output mode.

I've also added the `tagfile` field to the JSON output (to avoid ambiguity if there are multiple source files).

Let me know if there's anything I can change to help get this merged!