### PR TITLE
Example generator fix

### DIFF
--- a/examples/arguments.md
+++ b/examples/arguments.md
@@ -10,10 +10,11 @@ var arguments = 1; //: number
     "addr": "/arguments/",
     "kind": "v",
     "type": "number",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/arguments.js"
   }
 ]
 ```
 ```ctags
-arguments		/arguments/;"	v	lineno:1	type:number
+arguments	/usr/local/lib/node_modules/jsctags/test/cases/arguments.js	/arguments/;"	v	lineno:1	type:number
 ```

--- a/examples/autothis.md
+++ b/examples/autothis.md
@@ -19,7 +19,8 @@ new Date().fn2();
     "addr": "/Bar/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/autothis.js"
   },
   {
     "name": "hallo",
@@ -27,7 +28,8 @@ new Date().fn2();
     "kind": "f",
     "type": "void function()",
     "lineno": 2,
-    "namespace": "Bar.prototype"
+    "namespace": "Bar.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/autothis.js"
   },
   {
     "name": "fn2",
@@ -35,14 +37,13 @@ new Date().fn2();
     "kind": "f",
     "type": "void function()",
     "lineno": 11,
-    "namespace": "Date.prototype"
+    "namespace": "Date.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/autothis.js"
   }
 ]
 ```
 ```ctags
-Bar		/Bar/;"	f	lineno:1	type:void function()
-
-hallo		/hallo/;"	f	lineno:2	namespace:Bar.prototype	type:void function()
-
-fn2		/fn2/;"	f	lineno:11	namespace:Date.prototype	type:void function()
+Bar	/usr/local/lib/node_modules/jsctags/test/cases/autothis.js	/Bar/;"	f	lineno:1	type:void function()
+fn2	/usr/local/lib/node_modules/jsctags/test/cases/autothis.js	/fn2/;"	f	lineno:11	namespace:Date.prototype	type:void function()
+hallo	/usr/local/lib/node_modules/jsctags/test/cases/autothis.js	/hallo/;"	f	lineno:2	namespace:Bar.prototype	type:void function()
 ```

--- a/examples/browser.md
+++ b/examples/browser.md
@@ -18,19 +18,20 @@ e_which; //: number
     "addr": "/newElt/",
     "kind": "v",
     "type": "+Element",
-    "lineno": 5
+    "lineno": 5,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/browser.js"
   },
   {
     "name": "e_which",
     "addr": "/e_which/",
     "kind": "v",
     "type": "number",
-    "lineno": 9
+    "lineno": 9,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/browser.js"
   }
 ]
 ```
 ```ctags
-newElt		/newElt/;"	v	lineno:5	type:+Element
-
-e_which		/e_which/;"	v	lineno:9	type:number
+e_which	/usr/local/lib/node_modules/jsctags/test/cases/browser.js	/e_which/;"	v	lineno:9	type:number
+newElt	/usr/local/lib/node_modules/jsctags/test/cases/browser.js	/newElt/;"	v	lineno:5	type:+Element
 ```

--- a/examples/builtins.md
+++ b/examples/builtins.md
@@ -42,28 +42,29 @@ String.prototype.indexOf.bind("abcde", "a"); //: fn(from?: number) -> number
     "addr": "/x/",
     "kind": "v",
     "type": "number",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/builtins.js"
   },
   {
     "name": "a",
     "addr": "/a/",
     "kind": "v",
     "type": "[number]",
-    "lineno": 4
+    "lineno": 4,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/builtins.js"
   },
   {
     "name": "num",
     "addr": "/num/",
     "kind": "v",
     "type": "+Number",
-    "lineno": 26
+    "lineno": 26,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/builtins.js"
   }
 ]
 ```
 ```ctags
-x		/x/;"	v	lineno:1	type:number
-
-a		/a/;"	v	lineno:4	type:[number]
-
-num		/num/;"	v	lineno:26	type:+Number
+a	/usr/local/lib/node_modules/jsctags/test/cases/builtins.js	/a/;"	v	lineno:4	type:[number]
+num	/usr/local/lib/node_modules/jsctags/test/cases/builtins.js	/num/;"	v	lineno:26	type:+Number
+x	/usr/local/lib/node_modules/jsctags/test/cases/builtins.js	/x/;"	v	lineno:1	type:number
 ```

--- a/examples/cautiouspropagation.md
+++ b/examples/cautiouspropagation.md
@@ -19,10 +19,21 @@ simple[quux()]; //: string
     "addr": "/inner/",
     "kind": "v",
     "type": "number",
-    "lineno": 5
+    "lineno": 5,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/cautiouspropagation.js"
+  },
+  {
+    "name": "<i>",
+    "addr": "/foo\(\)/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 9,
+    "namespace": "simple",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/cautiouspropagation.js"
   }
 ]
 ```
 ```ctags
-inner		/inner/;"	v	lineno:5	type:number
+<i>	/usr/local/lib/node_modules/jsctags/test/cases/cautiouspropagation.js	/foo\(\)/;"	v	lineno:9	namespace:simple	type:string
+inner	/usr/local/lib/node_modules/jsctags/test/cases/cautiouspropagation.js	/inner/;"	v	lineno:5	type:number
 ```

--- a/examples/copyprops.md
+++ b/examples/copyprops.md
@@ -14,10 +14,11 @@ buildCopy({xx: 10, yy: 20}); //:: {xx: number, yy: number}
     "addr": "/buildCopy/",
     "kind": "f",
     "type": "? function(buildCopy.!0)",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/copyprops.js"
   }
 ]
 ```
 ```ctags
-buildCopy		/buildCopy/;"	f	lineno:1	type:? function(buildCopy.!0)
+buildCopy	/usr/local/lib/node_modules/jsctags/test/cases/copyprops.js	/buildCopy/;"	f	lineno:1	type:? function(buildCopy.!0)
 ```

--- a/examples/ctorpattern.md
+++ b/examples/ctorpattern.md
@@ -17,7 +17,8 @@ foo; //: ?
     "addr": "/Ctor/",
     "kind": "f",
     "type": "+Ctor function()",
-    "lineno": 4
+    "lineno": 4,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/ctorpattern.js"
   },
   {
     "name": "foo",
@@ -25,12 +26,12 @@ foo; //: ?
     "kind": "v",
     "type": "number",
     "lineno": 6,
-    "namespace": "Ctor"
+    "namespace": "Ctor",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/ctorpattern.js"
   }
 ]
 ```
 ```ctags
-Ctor		/Ctor/;"	f	lineno:4	type:+Ctor function()
-
-foo		/foo/;"	v	lineno:6	namespace:Ctor	type:number
+Ctor	/usr/local/lib/node_modules/jsctags/test/cases/ctorpattern.js	/Ctor/;"	f	lineno:4	type:+Ctor function()
+foo	/usr/local/lib/node_modules/jsctags/test/cases/ctorpattern.js	/foo/;"	v	lineno:6	namespace:Ctor	type:number
 ```

--- a/examples/docstrings.md
+++ b/examples/docstrings.md
@@ -63,35 +63,40 @@ o.foo; //doc: The string "foo".
     "addr": "/foo/",
     "kind": "v",
     "type": "number",
-    "lineno": 9
+    "lineno": 9,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js"
   },
   {
     "name": "makeMonkey",
     "addr": "/makeMonkey/",
     "kind": "f",
     "type": "string function()",
-    "lineno": 14
+    "lineno": 14,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js"
   },
   {
     "name": "abc",
     "addr": "/abc/",
     "kind": "v",
     "type": "number",
-    "lineno": 26
+    "lineno": 26,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js"
   },
   {
     "name": "Quux",
     "addr": "/Quux/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 33
+    "lineno": 33,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js"
   },
   {
     "name": "baz",
     "addr": "/baz/",
     "kind": "v",
     "type": "string",
-    "lineno": 40
+    "lineno": 40,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js"
   },
   {
     "name": "getName",
@@ -99,7 +104,8 @@ o.foo; //doc: The string "foo".
     "kind": "f",
     "type": "!this.name function()",
     "lineno": 46,
-    "namespace": "o"
+    "namespace": "o",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js"
   },
   {
     "name": "name",
@@ -107,7 +113,8 @@ o.foo; //doc: The string "foo".
     "kind": "v",
     "type": "string",
     "lineno": 48,
-    "namespace": "o"
+    "namespace": "o",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js"
   },
   {
     "name": "foo",
@@ -115,24 +122,18 @@ o.foo; //doc: The string "foo".
     "kind": "v",
     "type": "string",
     "lineno": 52,
-    "namespace": "o"
+    "namespace": "o",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js"
   }
 ]
 ```
 ```ctags
-foo		/foo/;"	v	lineno:9	type:number
-
-makeMonkey		/makeMonkey/;"	f	lineno:14	type:string function()
-
-abc		/abc/;"	v	lineno:26	type:number
-
-Quux		/Quux/;"	f	lineno:33	type:void function()
-
-baz		/baz/;"	v	lineno:40	type:string
-
-getName		/getName/;"	f	lineno:46	namespace:o	type:!this.name function()
-
-name		/name/;"	v	lineno:48	namespace:o	type:string
-
-foo		/foo/;"	v	lineno:52	namespace:o	type:string
+Quux	/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js	/Quux/;"	f	lineno:33	type:void function()
+abc	/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js	/abc/;"	v	lineno:26	type:number
+baz	/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js	/baz/;"	v	lineno:40	type:string
+foo	/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js	/foo/;"	v	lineno:52	namespace:o	type:string
+foo	/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js	/foo/;"	v	lineno:9	type:number
+getName	/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js	/getName/;"	f	lineno:46	namespace:o	type:!this.name function()
+makeMonkey	/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js	/makeMonkey/;"	f	lineno:14	type:string function()
+name	/usr/local/lib/node_modules/jsctags/test/cases/docstrings.js	/name/;"	v	lineno:48	namespace:o	type:string
 ```

--- a/examples/effects.md
+++ b/examples/effects.md
@@ -22,37 +22,38 @@ d; //: number
     "addr": "/b/",
     "kind": "v",
     "type": "[bool]",
-    "lineno": 3
+    "lineno": 3,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/effects.js"
   },
   {
     "name": "c",
     "addr": "/c/",
     "kind": "v",
-    "type": "[?]",
-    "lineno": 7
+    "type": "[string|number]",
+    "lineno": 7,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/effects.js"
   },
   {
     "name": "d",
     "addr": "/d/",
     "kind": "v",
     "type": "number",
-    "lineno": 12
+    "lineno": 12,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/effects.js"
   },
   {
     "name": "setD",
     "addr": "/setD/",
     "kind": "f",
     "type": "void function(number)",
-    "lineno": 13
+    "lineno": 13,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/effects.js"
   }
 ]
 ```
 ```ctags
-b		/b/;"	v	lineno:3	type:[bool]
-
-c		/c/;"	v	lineno:7	type:[?]
-
-d		/d/;"	v	lineno:12	type:number
-
-setD		/setD/;"	f	lineno:13	type:void function(number)
+b	/usr/local/lib/node_modules/jsctags/test/cases/effects.js	/b/;"	v	lineno:3	type:[bool]
+c	/usr/local/lib/node_modules/jsctags/test/cases/effects.js	/c/;"	v	lineno:7	type:[string|number]
+d	/usr/local/lib/node_modules/jsctags/test/cases/effects.js	/d/;"	v	lineno:12	type:number
+setD	/usr/local/lib/node_modules/jsctags/test/cases/effects.js	/setD/;"	f	lineno:13	type:void function(number)
 ```

--- a/examples/extends.md
+++ b/examples/extends.md
@@ -67,14 +67,16 @@ two.methodEleven; //: ?
     "addr": "/__extends/",
     "kind": "f",
     "type": "void function(fn(arg: bool)",
-    "lineno": 3
+    "lineno": 3,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "Top",
     "addr": "/Top/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 10
+    "lineno": 10,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "topMethod",
@@ -82,7 +84,8 @@ two.methodEleven; //: ?
     "kind": "f",
     "type": "string function()",
     "lineno": 12,
-    "namespace": "Top.prototype"
+    "namespace": "Top.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "topStatic",
@@ -90,14 +93,16 @@ two.methodEleven; //: ?
     "kind": "v",
     "type": "number",
     "lineno": 13,
-    "namespace": "Top"
+    "namespace": "Top",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "SubOne",
     "addr": "/SubOne/",
     "kind": "f",
     "type": "void function(bool)",
-    "lineno": 17
+    "lineno": 17,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "argOne",
@@ -105,7 +110,8 @@ two.methodEleven; //: ?
     "kind": "v",
     "type": "boolean",
     "lineno": 18,
-    "namespace": "SubOne"
+    "namespace": "SubOne",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "argOne",
@@ -113,7 +119,8 @@ two.methodEleven; //: ?
     "kind": "v",
     "type": "boolean",
     "lineno": 18,
-    "namespace": "SubEleven"
+    "namespace": "SubEleven",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "methodOne",
@@ -121,14 +128,16 @@ two.methodEleven; //: ?
     "kind": "f",
     "type": "number function()",
     "lineno": 20,
-    "namespace": "SubOne.prototype"
+    "namespace": "SubOne.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "SubTwo",
     "addr": "/SubTwo/",
     "kind": "f",
     "type": "void function(bool)",
-    "lineno": 24
+    "lineno": 24,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "argTwo",
@@ -136,7 +145,8 @@ two.methodEleven; //: ?
     "kind": "v",
     "type": "boolean",
     "lineno": 25,
-    "namespace": "SubTwo"
+    "namespace": "SubTwo",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "methodTwo",
@@ -144,14 +154,16 @@ two.methodEleven; //: ?
     "kind": "f",
     "type": "void function()",
     "lineno": 27,
-    "namespace": "SubTwo.prototype"
+    "namespace": "SubTwo.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "SubEleven",
     "addr": "/SubEleven/",
     "kind": "f",
     "type": "void function(bool)",
-    "lineno": 31
+    "lineno": 31,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "methodEleven",
@@ -159,61 +171,50 @@ two.methodEleven; //: ?
     "kind": "f",
     "type": "string function()",
     "lineno": 34,
-    "namespace": "SubEleven.prototype"
+    "namespace": "SubEleven.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "one",
     "addr": "/one/",
     "kind": "v",
     "type": "+SubOne",
-    "lineno": 38
+    "lineno": 38,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "two",
     "addr": "/two/",
     "kind": "v",
     "type": "+SubTwo",
-    "lineno": 38
+    "lineno": 38,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   },
   {
     "name": "elf",
     "addr": "/elf/",
     "kind": "v",
     "type": "+SubEleven",
-    "lineno": 38
+    "lineno": 38,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/extends.js"
   }
 ]
 ```
 ```ctags
-__extends		/__extends/;"	f	lineno:3	type:void function(fn(arg: bool)
-
-Top		/Top/;"	f	lineno:10	type:void function()
-
-topMethod		/topMethod/;"	f	lineno:12	namespace:Top.prototype	type:string function()
-
-topStatic		/topStatic/;"	v	lineno:13	namespace:Top	type:number
-
-SubOne		/SubOne/;"	f	lineno:17	type:void function(bool)
-
-argOne		/argOne/;"	v	lineno:18	namespace:SubOne	type:boolean
-
-argOne		/argOne/;"	v	lineno:18	namespace:SubEleven	type:boolean
-
-methodOne		/methodOne/;"	f	lineno:20	namespace:SubOne.prototype	type:number function()
-
-SubTwo		/SubTwo/;"	f	lineno:24	type:void function(bool)
-
-argTwo		/argTwo/;"	v	lineno:25	namespace:SubTwo	type:boolean
-
-methodTwo		/methodTwo/;"	f	lineno:27	namespace:SubTwo.prototype	type:void function()
-
-SubEleven		/SubEleven/;"	f	lineno:31	type:void function(bool)
-
-methodEleven		/methodEleven/;"	f	lineno:34	namespace:SubEleven.prototype	type:string function()
-
-one		/one/;"	v	lineno:38	type:+SubOne
-
-two		/two/;"	v	lineno:38	type:+SubTwo
-
-elf		/elf/;"	v	lineno:38	type:+SubEleven
+SubEleven	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/SubEleven/;"	f	lineno:31	type:void function(bool)
+SubOne	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/SubOne/;"	f	lineno:17	type:void function(bool)
+SubTwo	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/SubTwo/;"	f	lineno:24	type:void function(bool)
+Top	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/Top/;"	f	lineno:10	type:void function()
+__extends	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/__extends/;"	f	lineno:3	type:void function(fn(arg: bool)
+argOne	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/argOne/;"	v	lineno:18	namespace:SubEleven	type:boolean
+argOne	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/argOne/;"	v	lineno:18	namespace:SubOne	type:boolean
+argTwo	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/argTwo/;"	v	lineno:25	namespace:SubTwo	type:boolean
+elf	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/elf/;"	v	lineno:38	type:+SubEleven
+methodEleven	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/methodEleven/;"	f	lineno:34	namespace:SubEleven.prototype	type:string function()
+methodOne	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/methodOne/;"	f	lineno:20	namespace:SubOne.prototype	type:number function()
+methodTwo	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/methodTwo/;"	f	lineno:27	namespace:SubTwo.prototype	type:void function()
+one	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/one/;"	v	lineno:38	type:+SubOne
+topMethod	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/topMethod/;"	f	lineno:12	namespace:Top.prototype	type:string function()
+topStatic	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/topStatic/;"	v	lineno:13	namespace:Top	type:number
+two	/usr/local/lib/node_modules/jsctags/test/cases/extends.js	/two/;"	v	lineno:38	type:+SubTwo
 ```

--- a/examples/finddef.md
+++ b/examples/finddef.md
@@ -34,14 +34,16 @@ function another(arg) {
     "addr": "/blah/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/finddef.js"
   },
   {
     "name": "jaja",
     "addr": "/jaja/",
     "kind": "v",
     "type": "number",
-    "lineno": 3
+    "lineno": 3,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/finddef.js"
   },
   {
     "name": "prop1",
@@ -49,7 +51,8 @@ function another(arg) {
     "kind": "v",
     "type": "number",
     "lineno": 6,
-    "namespace": "obj"
+    "namespace": "obj",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/finddef.js"
   },
   {
     "name": "prop2",
@@ -57,7 +60,8 @@ function another(arg) {
     "kind": "f",
     "type": "void function(?)",
     "lineno": 7,
-    "namespace": "obj"
+    "namespace": "obj",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/finddef.js"
   },
   {
     "name": "prop3",
@@ -65,36 +69,33 @@ function another(arg) {
     "kind": "v",
     "type": "string",
     "lineno": 10,
-    "namespace": "obj"
+    "namespace": "obj",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/finddef.js"
   },
   {
     "name": "hide",
     "addr": "/hide/",
     "kind": "f",
     "type": "fn(foo: ?) function()",
-    "lineno": 19
+    "lineno": 19,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/finddef.js"
   },
   {
     "name": "another",
     "addr": "/another/",
     "kind": "f",
     "type": "void function(?)",
-    "lineno": 23
+    "lineno": 23,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/finddef.js"
   }
 ]
 ```
 ```ctags
-blah		/blah/;"	f	lineno:1	type:void function()
-
-jaja		/jaja/;"	v	lineno:3	type:number
-
-prop1		/prop1/;"	v	lineno:6	namespace:obj	type:number
-
-prop2		/prop2/;"	f	lineno:7	namespace:obj	type:void function(?)
-
-prop3		/prop3/;"	v	lineno:10	namespace:obj	type:string
-
-hide		/hide/;"	f	lineno:19	type:fn(foo: ?) function()
-
-another		/another/;"	f	lineno:23	type:void function(?)
+another	/usr/local/lib/node_modules/jsctags/test/cases/finddef.js	/another/;"	f	lineno:23	type:void function(?)
+blah	/usr/local/lib/node_modules/jsctags/test/cases/finddef.js	/blah/;"	f	lineno:1	type:void function()
+hide	/usr/local/lib/node_modules/jsctags/test/cases/finddef.js	/hide/;"	f	lineno:19	type:fn(foo: ?) function()
+jaja	/usr/local/lib/node_modules/jsctags/test/cases/finddef.js	/jaja/;"	v	lineno:3	type:number
+prop1	/usr/local/lib/node_modules/jsctags/test/cases/finddef.js	/prop1/;"	v	lineno:6	namespace:obj	type:number
+prop2	/usr/local/lib/node_modules/jsctags/test/cases/finddef.js	/prop2/;"	f	lineno:7	namespace:obj	type:void function(?)
+prop3	/usr/local/lib/node_modules/jsctags/test/cases/finddef.js	/prop3/;"	v	lineno:10	namespace:obj	type:string
 ```

--- a/examples/findref.md
+++ b/examples/findref.md
@@ -27,7 +27,8 @@ obj.z; //refs: 17,4 20,4
     "addr": "/hello/",
     "kind": "f",
     "type": "void function(?, ?)",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/findref.js"
   },
   {
     "name": "x",
@@ -35,7 +36,8 @@ obj.z; //refs: 17,4 20,4
     "kind": "v",
     "type": "number",
     "lineno": 11,
-    "namespace": "obj"
+    "namespace": "obj",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/findref.js"
   },
   {
     "name": "y",
@@ -43,7 +45,8 @@ obj.z; //refs: 17,4 20,4
     "kind": "v",
     "type": "number",
     "lineno": 13,
-    "namespace": "obj"
+    "namespace": "obj",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/findref.js"
   },
   {
     "name": "z",
@@ -51,16 +54,14 @@ obj.z; //refs: 17,4 20,4
     "kind": "v",
     "type": "string",
     "lineno": 17,
-    "namespace": "obj"
+    "namespace": "obj",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/findref.js"
   }
 ]
 ```
 ```ctags
-hello		/hello/;"	f	lineno:1	type:void function(?, ?)
-
-x		/x/;"	v	lineno:11	namespace:obj	type:number
-
-y		/y/;"	v	lineno:13	namespace:obj	type:number
-
-z		/z/;"	v	lineno:17	namespace:obj	type:string
+hello	/usr/local/lib/node_modules/jsctags/test/cases/findref.js	/hello/;"	f	lineno:1	type:void function(?, ?)
+x	/usr/local/lib/node_modules/jsctags/test/cases/findref.js	/x/;"	v	lineno:11	namespace:obj	type:number
+y	/usr/local/lib/node_modules/jsctags/test/cases/findref.js	/y/;"	v	lineno:13	namespace:obj	type:number
+z	/usr/local/lib/node_modules/jsctags/test/cases/findref.js	/z/;"	v	lineno:17	namespace:obj	type:string
 ```

--- a/examples/fn_arguments.md
+++ b/examples/fn_arguments.md
@@ -12,10 +12,11 @@ abc(1, 2, 3); //: number
     "addr": "/abc/",
     "kind": "f",
     "type": "number function()",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/fn_arguments.js"
   }
 ]
 ```
 ```ctags
-abc		/abc/;"	f	lineno:1	type:number function()
+abc	/usr/local/lib/node_modules/jsctags/test/cases/fn_arguments.js	/abc/;"	f	lineno:1	type:number function()
 ```

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-FILES=test/cases/*
+#!/bin/bash
+FILES=test/cases/*.js
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 for f in $FILES

--- a/examples/generic_each.md
+++ b/examples/generic_each.md
@@ -26,11 +26,12 @@ each([{x: 10}], function(o) {
     "name": "each",
     "addr": "/each/",
     "kind": "f",
-    "type": "void function(Array[each.!0.<i>], fn(o: each.!0.<i>)",
-    "lineno": 2
+    "type": "void function(Array[number]|[each.!0.<i>], fn(n: number)",
+    "lineno": 2,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/generic_each.js"
   }
 ]
 ```
 ```ctags
-each		/each/;"	f	lineno:2	type:void function(Array[each.!0.<i>], fn(o: each.!0.<i>)
+each	/usr/local/lib/node_modules/jsctags/test/cases/generic_each.js	/each/;"	f	lineno:2	type:void function(Array[number]|[each.!0.<i>], fn(n: number)
 ```

--- a/examples/global_this.md
+++ b/examples/global_this.md
@@ -12,10 +12,11 @@ var foo = 10;
     "addr": "/foo/",
     "kind": "v",
     "type": "number",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/global_this.js"
   }
 ]
 ```
 ```ctags
-foo		/foo/;"	v	lineno:1	type:number
+foo	/usr/local/lib/node_modules/jsctags/test/cases/global_this.js	/foo/;"	v	lineno:1	type:number
 ```

--- a/examples/infinite-expansion.md
+++ b/examples/infinite-expansion.md
@@ -26,28 +26,29 @@ goop(1)(goop);
     "addr": "/f/",
     "kind": "f",
     "type": "void function(f)",
-    "lineno": 3
+    "lineno": 3,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/infinite-expansion.js"
   },
   {
     "name": "x",
     "addr": "/x/",
     "kind": "v",
     "type": "[x]",
-    "lineno": 10
+    "lineno": 10,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/infinite-expansion.js"
   },
   {
     "name": "goop",
     "addr": "/goop/",
     "kind": "f",
     "type": "fn(f: ?) function(number)",
-    "lineno": 15
+    "lineno": 15,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/infinite-expansion.js"
   }
 ]
 ```
 ```ctags
-f		/f/;"	f	lineno:3	type:void function(f)
-
-x		/x/;"	v	lineno:10	type:[x]
-
-goop		/goop/;"	f	lineno:15	type:fn(f: ?) function(number)
+f	/usr/local/lib/node_modules/jsctags/test/cases/infinite-expansion.js	/f/;"	f	lineno:3	type:void function(f)
+goop	/usr/local/lib/node_modules/jsctags/test/cases/infinite-expansion.js	/goop/;"	f	lineno:15	type:fn(f: ?) function(number)
+x	/usr/local/lib/node_modules/jsctags/test/cases/infinite-expansion.js	/x/;"	v	lineno:10	type:[x]
 ```

--- a/examples/jsdoc.md
+++ b/examples/jsdoc.md
@@ -45,43 +45,63 @@ o.prop3; //: fn() -> string
 ```json
 [
   {
+    "name": "a",
+    "addr": "/a/",
+    "kind": "v",
+    "type": "+Date",
+    "lineno": 2,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js"
+  },
+  {
     "name": "foo",
     "addr": "/foo/",
     "kind": "f",
-    "type": "void function(?, ?)",
-    "lineno": 17
+    "type": "Array function(number, string)",
+    "lineno": 17,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js"
   },
   {
     "name": "bar",
     "addr": "/bar/",
     "kind": "f",
-    "type": "void function(?, number)",
-    "lineno": 25
+    "type": "string function(number, number)",
+    "lineno": 25,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js"
+  },
+  {
+    "name": "prop1",
+    "addr": "/prop1/",
+    "kind": "v",
+    "type": "string",
+    "lineno": 31,
+    "namespace": "o",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js"
   },
   {
     "name": "prop2",
     "addr": "/prop2/",
     "kind": "f",
-    "type": "void function()",
+    "type": "number function()",
     "lineno": 34,
-    "namespace": "o"
+    "namespace": "o",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js"
   },
   {
     "name": "prop3",
     "addr": "/prop3/",
     "kind": "f",
-    "type": "void function()",
+    "type": "string function()",
     "lineno": 38,
-    "namespace": "o"
+    "namespace": "o",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js"
   }
 ]
 ```
 ```ctags
-foo		/foo/;"	f	lineno:17	type:void function(?, ?)
-
-bar		/bar/;"	f	lineno:25	type:void function(?, number)
-
-prop2		/prop2/;"	f	lineno:34	namespace:o	type:void function()
-
-prop3		/prop3/;"	f	lineno:38	namespace:o	type:void function()
+a	/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js	/a/;"	v	lineno:2	type:+Date
+bar	/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js	/bar/;"	f	lineno:25	type:string function(number, number)
+foo	/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js	/foo/;"	f	lineno:17	type:Array function(number, string)
+prop1	/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js	/prop1/;"	v	lineno:31	namespace:o	type:string
+prop2	/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js	/prop2/;"	f	lineno:34	namespace:o	type:number function()
+prop3	/usr/local/lib/node_modules/jsctags/test/cases/jsdoc.js	/prop3/;"	f	lineno:38	namespace:o	type:string function()
 ```

--- a/examples/merge.md
+++ b/examples/merge.md
@@ -14,11 +14,12 @@ sum; //:: fn(a: {x: number, y: number}) -> number
     "name": "sum",
     "addr": "/sum/",
     "kind": "f",
-    "type": "number function(sum.!0)",
-    "lineno": 1
+    "type": "number function(?)",
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/merge.js"
   }
 ]
 ```
 ```ctags
-sum		/sum/;"	f	lineno:1	type:number function(sum.!0)
+sum	/usr/local/lib/node_modules/jsctags/test/cases/merge.js	/sum/;"	f	lineno:1	type:number function(?)
 ```

--- a/examples/new_array.md
+++ b/examples/new_array.md
@@ -19,37 +19,38 @@ d[0]; //: string
     "addr": "/a/",
     "kind": "v",
     "type": "[string]",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_array.js"
   },
   {
     "name": "b",
     "addr": "/b/",
     "kind": "v",
     "type": "[bool]",
-    "lineno": 5
+    "lineno": 5,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_array.js"
   },
   {
     "name": "c",
     "addr": "/c/",
     "kind": "v",
     "type": "[?]",
-    "lineno": 8
+    "lineno": 8,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_array.js"
   },
   {
     "name": "d",
     "addr": "/d/",
     "kind": "v",
     "type": "[string]",
-    "lineno": 11
+    "lineno": 11,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_array.js"
   }
 ]
 ```
 ```ctags
-a		/a/;"	v	lineno:1	type:[string]
-
-b		/b/;"	v	lineno:5	type:[bool]
-
-c		/c/;"	v	lineno:8	type:[?]
-
-d		/d/;"	v	lineno:11	type:[string]
+a	/usr/local/lib/node_modules/jsctags/test/cases/new_array.js	/a/;"	v	lineno:1	type:[string]
+b	/usr/local/lib/node_modules/jsctags/test/cases/new_array.js	/b/;"	v	lineno:5	type:[bool]
+c	/usr/local/lib/node_modules/jsctags/test/cases/new_array.js	/c/;"	v	lineno:8	type:[?]
+d	/usr/local/lib/node_modules/jsctags/test/cases/new_array.js	/d/;"	v	lineno:11	type:[string]
 ```

--- a/examples/new_to_prototype.md
+++ b/examples/new_to_prototype.md
@@ -21,7 +21,8 @@ C.prototype.prop_C = 3;
     "addr": "/A/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js"
   },
   {
     "name": "prop_A",
@@ -29,14 +30,16 @@ C.prototype.prop_C = 3;
     "kind": "v",
     "type": "number",
     "lineno": 2,
-    "namespace": "A.prototype"
+    "namespace": "A.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js"
   },
   {
     "name": "B",
     "addr": "/B/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 3
+    "lineno": 3,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js"
   },
   {
     "name": "prop_B",
@@ -44,14 +47,16 @@ C.prototype.prop_C = 3;
     "kind": "v",
     "type": "number",
     "lineno": 5,
-    "namespace": "B.prototype"
+    "namespace": "B.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js"
   },
   {
     "name": "C",
     "addr": "/C/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 6
+    "lineno": 6,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js"
   },
   {
     "name": "prop_C",
@@ -59,20 +64,16 @@ C.prototype.prop_C = 3;
     "kind": "v",
     "type": "number",
     "lineno": 8,
-    "namespace": "C.prototype"
+    "namespace": "C.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js"
   }
 ]
 ```
 ```ctags
-A		/A/;"	f	lineno:1	type:void function()
-
-prop_A		/prop_A/;"	v	lineno:2	namespace:A.prototype	type:number
-
-B		/B/;"	f	lineno:3	type:void function()
-
-prop_B		/prop_B/;"	v	lineno:5	namespace:B.prototype	type:number
-
-C		/C/;"	f	lineno:6	type:void function()
-
-prop_C		/prop_C/;"	v	lineno:8	namespace:C.prototype	type:number
+A	/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js	/A/;"	f	lineno:1	type:void function()
+B	/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js	/B/;"	f	lineno:3	type:void function()
+C	/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js	/C/;"	f	lineno:6	type:void function()
+prop_A	/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js	/prop_A/;"	v	lineno:2	namespace:A.prototype	type:number
+prop_B	/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js	/prop_B/;"	v	lineno:5	namespace:B.prototype	type:number
+prop_C	/usr/local/lib/node_modules/jsctags/test/cases/new_to_prototype.js	/prop_C/;"	v	lineno:8	namespace:C.prototype	type:number
 ```

--- a/examples/object_create.md
+++ b/examples/object_create.md
@@ -41,7 +41,8 @@ empty.prop1; //: string
     "kind": "v",
     "type": "number",
     "lineno": 1,
-    "namespace": "base"
+    "namespace": "base",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/object_create.js"
   },
   {
     "name": "bar",
@@ -49,7 +50,8 @@ empty.prop1; //: string
     "kind": "v",
     "type": "number",
     "lineno": 1,
-    "namespace": "base"
+    "namespace": "base",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/object_create.js"
   },
   {
     "name": "baz",
@@ -57,7 +59,8 @@ empty.prop1; //: string
     "kind": "v",
     "type": "number",
     "lineno": 5,
-    "namespace": "base"
+    "namespace": "base",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/object_create.js"
   },
   {
     "name": "quux",
@@ -65,7 +68,8 @@ empty.prop1; //: string
     "kind": "v",
     "type": "number",
     "lineno": 6,
-    "namespace": "gen1"
+    "namespace": "gen1",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/object_create.js"
   },
   {
     "name": "kaka",
@@ -73,7 +77,8 @@ empty.prop1; //: string
     "kind": "v",
     "type": "number",
     "lineno": 7,
-    "namespace": "gen2"
+    "namespace": "gen2",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/object_create.js"
   },
   {
     "name": "prop1",
@@ -81,20 +86,16 @@ empty.prop1; //: string
     "kind": "v",
     "type": "string",
     "lineno": 30,
-    "namespace": "empty"
+    "namespace": "empty",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/object_create.js"
   }
 ]
 ```
 ```ctags
-foo		/foo/;"	v	lineno:1	namespace:base	type:number
-
-bar		/bar/;"	v	lineno:1	namespace:base	type:number
-
-baz		/baz/;"	v	lineno:5	namespace:base	type:number
-
-quux		/quux/;"	v	lineno:6	namespace:gen1	type:number
-
-kaka		/kaka/;"	v	lineno:7	namespace:gen2	type:number
-
-prop1		/prop1/;"	v	lineno:30	namespace:empty	type:string
+bar	/usr/local/lib/node_modules/jsctags/test/cases/object_create.js	/bar/;"	v	lineno:1	namespace:base	type:number
+baz	/usr/local/lib/node_modules/jsctags/test/cases/object_create.js	/baz/;"	v	lineno:5	namespace:base	type:number
+foo	/usr/local/lib/node_modules/jsctags/test/cases/object_create.js	/foo/;"	v	lineno:1	namespace:base	type:number
+kaka	/usr/local/lib/node_modules/jsctags/test/cases/object_create.js	/kaka/;"	v	lineno:7	namespace:gen2	type:number
+prop1	/usr/local/lib/node_modules/jsctags/test/cases/object_create.js	/prop1/;"	v	lineno:30	namespace:empty	type:string
+quux	/usr/local/lib/node_modules/jsctags/test/cases/object_create.js	/quux/;"	v	lineno:6	namespace:gen1	type:number
 ```

--- a/examples/objnames.md
+++ b/examples/objnames.md
@@ -16,7 +16,8 @@ new Ctor2(); //: Ctor2
     "addr": "/Ctor1/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/objnames.js"
   },
   {
     "name": "a",
@@ -24,14 +25,16 @@ new Ctor2(); //: Ctor2
     "kind": "v",
     "type": "number",
     "lineno": 2,
-    "namespace": "Ctor1.prototype"
+    "namespace": "Ctor1.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/objnames.js"
   },
   {
     "name": "Ctor2",
     "addr": "/Ctor2/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 4
+    "lineno": 4,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/objnames.js"
   },
   {
     "name": "a",
@@ -39,7 +42,8 @@ new Ctor2(); //: Ctor2
     "kind": "v",
     "type": "number",
     "lineno": 6,
-    "namespace": "singleton"
+    "namespace": "singleton",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/objnames.js"
   },
   {
     "name": "b",
@@ -47,18 +51,15 @@ new Ctor2(); //: Ctor2
     "kind": "v",
     "type": "number",
     "lineno": 6,
-    "namespace": "singleton"
+    "namespace": "singleton",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/objnames.js"
   }
 ]
 ```
 ```ctags
-Ctor1		/Ctor1/;"	f	lineno:1	type:void function()
-
-a		/a/;"	v	lineno:2	namespace:Ctor1.prototype	type:number
-
-Ctor2		/Ctor2/;"	f	lineno:4	type:void function()
-
-a		/a/;"	v	lineno:6	namespace:singleton	type:number
-
-b		/b/;"	v	lineno:6	namespace:singleton	type:number
+Ctor1	/usr/local/lib/node_modules/jsctags/test/cases/objnames.js	/Ctor1/;"	f	lineno:1	type:void function()
+Ctor2	/usr/local/lib/node_modules/jsctags/test/cases/objnames.js	/Ctor2/;"	f	lineno:4	type:void function()
+a	/usr/local/lib/node_modules/jsctags/test/cases/objnames.js	/a/;"	v	lineno:2	namespace:Ctor1.prototype	type:number
+a	/usr/local/lib/node_modules/jsctags/test/cases/objnames.js	/a/;"	v	lineno:6	namespace:singleton	type:number
+b	/usr/local/lib/node_modules/jsctags/test/cases/objnames.js	/b/;"	v	lineno:6	namespace:singleton	type:number
 ```

--- a/examples/plus.md
+++ b/examples/plus.md
@@ -14,19 +14,20 @@ x + y; //: string
     "addr": "/x/",
     "kind": "v",
     "type": "number",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/plus.js"
   },
   {
     "name": "y",
     "addr": "/y/",
     "kind": "v",
     "type": "string",
-    "lineno": 2
+    "lineno": 2,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/plus.js"
   }
 ]
 ```
 ```ctags
-x		/x/;"	v	lineno:1	type:number
-
-y		/y/;"	v	lineno:2	type:string
+x	/usr/local/lib/node_modules/jsctags/test/cases/plus.js	/x/;"	v	lineno:1	type:number
+y	/usr/local/lib/node_modules/jsctags/test/cases/plus.js	/y/;"	v	lineno:2	type:string
 ```

--- a/examples/proto.md
+++ b/examples/proto.md
@@ -23,7 +23,8 @@ z.bar; //: number
     "addr": "/Foo/",
     "kind": "f",
     "type": "void function(bool)",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/proto.js"
   },
   {
     "name": "x",
@@ -31,7 +32,8 @@ z.bar; //: number
     "kind": "v",
     "type": "boolean",
     "lineno": 2,
-    "namespace": "Foo"
+    "namespace": "Foo",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/proto.js"
   },
   {
     "name": "y",
@@ -39,7 +41,8 @@ z.bar; //: number
     "kind": "v",
     "type": "[number]",
     "lineno": 3,
-    "namespace": "Foo"
+    "namespace": "Foo",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/proto.js"
   },
   {
     "name": "makeString",
@@ -47,7 +50,8 @@ z.bar; //: number
     "kind": "f",
     "type": "string function()",
     "lineno": 8,
-    "namespace": "Foo.prototype"
+    "namespace": "Foo.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/proto.js"
   },
   {
     "name": "bar",
@@ -55,27 +59,24 @@ z.bar; //: number
     "kind": "v",
     "type": "number",
     "lineno": 9,
-    "namespace": "Foo.prototype"
+    "namespace": "Foo.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/proto.js"
   },
   {
     "name": "z",
     "addr": "/z/",
     "kind": "v",
     "type": "+Foo",
-    "lineno": 12
+    "lineno": 12,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/proto.js"
   }
 ]
 ```
 ```ctags
-Foo		/Foo/;"	f	lineno:1	type:void function(bool)
-
-x		/x/;"	v	lineno:2	namespace:Foo	type:boolean
-
-y		/y/;"	v	lineno:3	namespace:Foo	type:[number]
-
-makeString		/makeString/;"	f	lineno:8	namespace:Foo.prototype	type:string function()
-
-bar		/bar/;"	v	lineno:9	namespace:Foo.prototype	type:number
-
-z		/z/;"	v	lineno:12	type:+Foo
+Foo	/usr/local/lib/node_modules/jsctags/test/cases/proto.js	/Foo/;"	f	lineno:1	type:void function(bool)
+bar	/usr/local/lib/node_modules/jsctags/test/cases/proto.js	/bar/;"	v	lineno:9	namespace:Foo.prototype	type:number
+makeString	/usr/local/lib/node_modules/jsctags/test/cases/proto.js	/makeString/;"	f	lineno:8	namespace:Foo.prototype	type:string function()
+x	/usr/local/lib/node_modules/jsctags/test/cases/proto.js	/x/;"	v	lineno:2	namespace:Foo	type:boolean
+y	/usr/local/lib/node_modules/jsctags/test/cases/proto.js	/y/;"	v	lineno:3	namespace:Foo	type:[number]
+z	/usr/local/lib/node_modules/jsctags/test/cases/proto.js	/z/;"	v	lineno:12	type:+Foo
 ```

--- a/examples/protoname.md
+++ b/examples/protoname.md
@@ -27,46 +27,47 @@ new Sub3(); //: Sub3
     "addr": "/Base/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/protoname.js"
   },
   {
     "name": "Sub1",
     "addr": "/Sub1/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 7
+    "lineno": 7,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/protoname.js"
   },
   {
     "name": "Sub2",
     "addr": "/Sub2/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 11
+    "lineno": 11,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/protoname.js"
   },
   {
     "name": "Base2",
     "addr": "/Base2/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 15
+    "lineno": 15,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/protoname.js"
   },
   {
     "name": "Sub3",
     "addr": "/Sub3/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 17
+    "lineno": 17,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/protoname.js"
   }
 ]
 ```
 ```ctags
-Base		/Base/;"	f	lineno:1	type:void function()
-
-Sub1		/Sub1/;"	f	lineno:7	type:void function()
-
-Sub2		/Sub2/;"	f	lineno:11	type:void function()
-
-Base2		/Base2/;"	f	lineno:15	type:void function()
-
-Sub3		/Sub3/;"	f	lineno:17	type:void function()
+Base	/usr/local/lib/node_modules/jsctags/test/cases/protoname.js	/Base/;"	f	lineno:1	type:void function()
+Base2	/usr/local/lib/node_modules/jsctags/test/cases/protoname.js	/Base2/;"	f	lineno:15	type:void function()
+Sub1	/usr/local/lib/node_modules/jsctags/test/cases/protoname.js	/Sub1/;"	f	lineno:7	type:void function()
+Sub2	/usr/local/lib/node_modules/jsctags/test/cases/protoname.js	/Sub2/;"	f	lineno:11	type:void function()
+Sub3	/usr/local/lib/node_modules/jsctags/test/cases/protoname.js	/Sub3/;"	f	lineno:17	type:void function()
 ```

--- a/examples/replace_bogus_prop.md
+++ b/examples/replace_bogus_prop.md
@@ -13,14 +13,16 @@ Type.prototype.foo = "hi";
     "addr": "/x/",
     "kind": "v",
     "type": "+Type",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/replace_bogus_prop.js"
   },
   {
     "name": "Type",
     "addr": "/Type/",
     "kind": "f",
     "type": "void function()",
-    "lineno": 5
+    "lineno": 5,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/replace_bogus_prop.js"
   },
   {
     "name": "foo",
@@ -28,14 +30,13 @@ Type.prototype.foo = "hi";
     "kind": "v",
     "type": "string",
     "lineno": 6,
-    "namespace": "Type.prototype"
+    "namespace": "Type.prototype",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/replace_bogus_prop.js"
   }
 ]
 ```
 ```ctags
-x		/x/;"	v	lineno:1	type:+Type
-
-Type		/Type/;"	f	lineno:5	type:void function()
-
-foo		/foo/;"	v	lineno:6	namespace:Type.prototype	type:string
+Type	/usr/local/lib/node_modules/jsctags/test/cases/replace_bogus_prop.js	/Type/;"	f	lineno:5	type:void function()
+foo	/usr/local/lib/node_modules/jsctags/test/cases/replace_bogus_prop.js	/foo/;"	v	lineno:6	namespace:Type.prototype	type:string
+x	/usr/local/lib/node_modules/jsctags/test/cases/replace_bogus_prop.js	/x/;"	v	lineno:1	type:+Type
 ```

--- a/examples/simple.md
+++ b/examples/simple.md
@@ -22,14 +22,16 @@ x; //:: {bar: number, foo: number}
     "addr": "/foo/",
     "kind": "v",
     "type": "number",
-    "lineno": 1
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/simple.js"
   },
   {
     "name": "init",
     "addr": "/init/",
     "kind": "f",
     "type": "void function(x)",
-    "lineno": 8
+    "lineno": 8,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/simple.js"
   },
   {
     "name": "foo",
@@ -37,7 +39,8 @@ x; //:: {bar: number, foo: number}
     "kind": "v",
     "type": "number",
     "lineno": 9,
-    "namespace": "x"
+    "namespace": "x",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/simple.js"
   },
   {
     "name": "bar",
@@ -45,16 +48,14 @@ x; //:: {bar: number, foo: number}
     "kind": "v",
     "type": "number",
     "lineno": 10,
-    "namespace": "x"
+    "namespace": "x",
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/simple.js"
   }
 ]
 ```
 ```ctags
-foo		/foo/;"	v	lineno:1	type:number
-
-init		/init/;"	f	lineno:8	type:void function(x)
-
-foo		/foo/;"	v	lineno:9	namespace:x	type:number
-
-bar		/bar/;"	v	lineno:10	namespace:x	type:number
+bar	/usr/local/lib/node_modules/jsctags/test/cases/simple.js	/bar/;"	v	lineno:10	namespace:x	type:number
+foo	/usr/local/lib/node_modules/jsctags/test/cases/simple.js	/foo/;"	v	lineno:1	type:number
+foo	/usr/local/lib/node_modules/jsctags/test/cases/simple.js	/foo/;"	v	lineno:9	namespace:x	type:number
+init	/usr/local/lib/node_modules/jsctags/test/cases/simple.js	/init/;"	f	lineno:8	type:void function(x)
 ```

--- a/examples/simple_generic.md
+++ b/examples/simple_generic.md
@@ -19,20 +19,21 @@ map([1, 2, 3], function() { return true; }); //: [bool]
     "name": "last",
     "addr": "/last/",
     "kind": "f",
-    "type": "!0.<i> function(Array[string])",
-    "lineno": 1
+    "type": "!0.<i> function(Array[number]|[string])",
+    "lineno": 1,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/simple_generic.js"
   },
   {
     "name": "map",
     "addr": "/map/",
     "kind": "f",
-    "type": "bool) -> [?] function(Array[number], fn()",
-    "lineno": 6
+    "type": "string|fn() -> bool) -> [?] function(Array[number], fn()",
+    "lineno": 6,
+    "tagfile": "/usr/local/lib/node_modules/jsctags/test/cases/simple_generic.js"
   }
 ]
 ```
 ```ctags
-last		/last/;"	f	lineno:1	type:!0.<i> function(Array[string])
-
-map		/map/;"	f	lineno:6	type:bool) -> [?] function(Array[number], fn()
+last	/usr/local/lib/node_modules/jsctags/test/cases/simple_generic.js	/last/;"	f	lineno:1	type:!0.<i> function(Array[number]|[string])
+map	/usr/local/lib/node_modules/jsctags/test/cases/simple_generic.js	/map/;"	f	lineno:6	type:string|fn() -> bool) -> [?] function(Array[number], fn()
 ```


### PR DESCRIPTION
This fixes the `examples/generate.sh` script and updates the examples (in response to #22).

I've made two changes to the generator script:
- only include `*.js` files to generate the examples (i.e. ignoring `.json` and `.tags` files)
- changed shell from `/bin/sh` to `/bin/bash` to allow `echo -e` option on OS X

This should fix #24.