### PR TITLE
the command in readme that used by generate the ctags for vim incorrect

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,13 +51,13 @@ jsctags(file, dir, content, function(e, tags) {
 If you'd like to take a JavaScript project and generate a `tags` file that Vim can parse, you can use the below command. It searches your directory for any `.js` files, excluding `./node_modules`, formats the tags correctly for Vim and outputs them into `tags`.
 
 ```bash
-find . -type f -iregex .*\.js$ -not -path "./node_modules/*" -exec jsctags {} -f \; | sed '/^$/d' | sort > tags
+find . -type f -iregex ".*\.js$" -not -path "./node_modules/*" -exec jsctags {} -f \; | sed '/^$/d' | sort > tags
 ```
 
 If you would like tags generated for files within `node_modules/`, just remove the `-not -path "./node_modules/*` part of the command:
 
 ```bash
-find . -type f -iregex .*\.js$ -exec jsctags {} -f \; | sed '/^$/d' | sort > tags
+find . -type f -iregex ".*\.js$" -exec jsctags {} -f \; | sed '/^$/d' | sort > tags
 ```
 
 ## examples


### PR DESCRIPTION
the command in readme that used by generate the ctags for vim seems incorrect in the mac zsh, the regex expression used for filter js files lack of the quotes. it will failing in the terminal.
the pr just add quotes.
