### PR TITLE
Improve plugin resolution.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 coverage
 .nyc_output
+.git

--- a/src/condenser.js
+++ b/src/condenser.js
@@ -55,6 +55,11 @@ var server = function(config, dir) {
 
     if (fs.existsSync(file)) {
       return require(file);
+    } else {
+      var tryRequire = function(name) {
+        return tryor(require.bind(require, name));
+      };
+      return tryRequire('tern-' + plugin) || tryRequire(plugin);
     }
   });
 


### PR DESCRIPTION
Problem: A lot of tern plugins follow the convention tern-{plugin-name}.
Solution: try requiring tern-{plugin-name}  if other way(s) fail.