### PR TITLE
Fixes the npm installation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "once": "^1.4.0",
     "optimist": "^0.6.1",
     "tern": "^0.21.0",
-    "tern-jsx": "ramitos/tern-jsx#bb32547",
+    "tern-jsx": "ramitos/tern-jsx#fc9b687",
     "tryor": "^0.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently, following the instructions in the `README`, the installation
fails with the following error:

```
194 silly fetchPackageMetaData error for acorn-jsx@github:ramitos/acorn-jsx#6683232 Command failed: /usr/local/bin/git checkout 6683232
194 silly fetchPackageMetaData error: pathspec '6683232' did not match any file(s) known to git.
195 timing stage:rollbackFailedOptional Completed in 0ms
196 timing stage:runTopLevelLifecycles Completed in 10566ms
197 verbose stack Error: Command failed: /usr/local/bin/git checkout 6683232
197 verbose stack error: pathspec '6683232' did not match any file(s) known to git.
```

The error seems related with the last commit in the repository
ramitos/acorn-jsx (https://github.com/ramitos/acorn-jsx/commit/3af8b5850c82340fb2e8dd3f0113827aa3757010)
which seems to break also the dependencies for ramitos/tern-jsx (https://github.com/ramitos/tern-jsx/commit/fc9b687ee6b9258dab63e59d4580338b6138873d)

This patch updates the `package.json` to point to the latest commit in
tern-jsx. The ideal fix would be to make it target the latest commit in
the master branch but this fix is consistent witht the design decisions
taken by the original author.