### PR TITLE
parser.js: use lineno() instead of addr()

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -354,7 +354,7 @@ Parser.prototype.onNode = function(name, node, parent) {
   const tag = {
     id: uuid.v1(),
     name,
-    addr: this.addr(node),
+    addr: this.lineno(node),
     kind: this.kind(node),
     type: this.type(node),
     lineno: this.lineno(node),


### PR DESCRIPTION
Using `this.addr(node)` sometimes gives wrong results. 
For example:
```js
class MyClass {
  constructor() {
    this.onClick()
  }
  
  onClick = () => {
    alert('ok')
  }
}
```
Outputs:
```
MyClass	/home/rgregoir/github/jsctags/test.js	/MyClass/;"	f	lineno:1	type:void function()
prototype	/home/rgregoir/github/jsctags/test.js	/class MyClass \{/;"	v	lineno:1	namespace:MyClass
onClick	/home/rgregoir/github/jsctags/test.js	/onClick/;"	f	lineno:6	namespace:MyClass.prototype	type:void function(?)
```

As you can see, the Ex command for `onClick` is `/onClick/`. However, that command lands on the first `onClick`, aka `this.onClick()`, which is the wrong position. Using the line number solves that issue, and is also way safer and more straight-forward.